### PR TITLE
Create output directory if title contains a slash (CLI)

### DIFF
--- a/cli/book.php
+++ b/cli/book.php
@@ -85,6 +85,9 @@ if(!isset($_SERVER['argc']) || $_SERVER['argc'] < 3) {
                 }
                 $file = $generator->create($data);
                 $path .= $title . '.' . $generator->getExtension();
+                if (!is_dir(dirname($path))) {
+                    mkdir(dirname($path), 0755, true);
+                }
                 if($fp = fopen($path, 'w')) {
                         fputs($fp, $file);
                 } else {


### PR DESCRIPTION
If a title contains a slash, first create parent directories before saving the output file.
