### PR TITLE
getPicturesList() -> new img class for TeX markup

### DIFF
--- a/book/BookProvider.php
+++ b/book/BookProvider.php
@@ -480,7 +480,7 @@ class PageParser {
                         $a->setAttribute('alt', $picture->title);
                         $node->parentNode->replaceChild($a, $node);
                 }
-                $list = $this->xPath->query('//html:img[@class="tex"]');
+                $list = $this->xPath->query('//html:img[substring(@class, string-length(@class) - 2) = "tex"]');
                 foreach($list as $img) {
                         $picture = new Picture();
                         $url = $img->getAttribute('src');


### PR DESCRIPTION
currently the class name  of mathematical formulas images (Wiki TeX markup) have changed to: class="mwe-math-fallback-png-inline tex". i propose to change the query to select all classes ending with "tex"... or [@class="mwe-math-fallback-png-inline tex"] ...
