### PR TITLE
Update Stat.php

### DIFF
--- a/book/Stat.php
+++ b/book/Stat.php
@@ -7,6 +7,7 @@
 
 class Stat {
         public static function add($format, $lang) {
+                if($format=='epub') $format='epub-2';
                 $stat = self::getStat();
                 if(isset($stat[$format][$lang]))
                     $stat[$format][$lang]++;
@@ -20,12 +21,6 @@ class Stat {
                 $path = self::getStatPath($month, $year);
                 if(file_exists($path)) {
                         $data = unserialize(file_get_contents($path));
-                        if(isset($data['epub'])) {
-                            $data['epub-2'] = isset($data['epub-2']) ? $data['epub-2'] + $data['epub'] : $data['epub'];
-                        } elseif(!isset($data['epub-2'])) {
-                            $data['epub-2'] = 0;
-                        }
-                        unset($data['epub']);
                         return $data;
                 } else
                         return array(

--- a/book/Stat.php
+++ b/book/Stat.php
@@ -7,7 +7,7 @@
 
 class Stat {
         public static function add($format, $lang) {
-                if($format=='epub') $format='epub-2';
+                if($format === 'epub') $format = 'epub-2';
                 $stat = self::getStat();
                 if(isset($stat[$format][$lang]))
                     $stat[$format][$lang]++;


### PR DESCRIPTION
at the moment stats (present and historical) are incorrect...
the fragment of the code:
```
if(isset($data['epub'])) {
   $data['epub-2'] = isset($data['epub-2']) ? $data['epub-2'] + $data['epub'] : $data['epub'];
} elseif(!isset($data['epub-2'])) {
   $data['epub-2'] = 0;
}
```
does not work properly - for example: if there are set a variables ```$data['epub-2']['pl']```, ```$data['epub-2']['en']``` and ```$data['epub']['pl']``` but there is no ```$data['epub']['en']``` the stats are "broken".
also code execution -> ```$data['epub-2'] = 0;``` causing that reading ```$data['epub-2']['pl'] $data['epub-2']['en']...``` for all lang. will result ```none``` (the present state of stats :)  "2" for 'pl' comes from 'epub-3" (!)).
After execution of the proposed changes current contents of the /stat/2015/1.sphp file should be erased (for 'epub' and  'epub-2' format).