### PR TITLE
non-clickable link for {URL} tag -> clickable one

### DIFF
--- a/book/formats/EpubGenerator.php
+++ b/book/formats/EpubGenerator.php
@@ -224,7 +224,7 @@ abstract class EpubGenerator implements FormatGenerator {
                 } else {
                         $about = str_replace('{CONTRIBUTORS}', $list, $about);
                         $about = str_replace('{BOT-CONTRIBUTORS}', $listBot, $about);
-                        $about = str_replace('{URL}', $wsUrl, $about);
+                        $about = str_replace('{URL}', '<a href="' . $wsUrl . '">' . htmlspecialchars($book->name, ENT_QUOTES) . '</a>', $about);
                 }
                 return $about;
         }


### PR DESCRIPTION
I have checked on bn, ca, da, de, el, en, et, fa, fr, hy, is, it, la, nl, no, pl, pt, ro, ru, te, vec and old wikisources. Only on the plwiki the {URL} tag is used. Changing into a clickable link may increase its popularity :), and enhance “About” section usability.