### PR TITLE
cover thumb picture for oldwikisource local file

### DIFF
--- a/book/BookProvider.php
+++ b/book/BookProvider.php
@@ -259,6 +259,8 @@ class BookProvider {
 				$picture->url = str_replace( 'commons/', 'commons/thumb/', $picture->url ) . '/page' . $id[1] . '-400px-' . $title . '.jpg';
 			} elseif( strstr( $picture->url, '/wikisource/' . $lang ) ) {
 				$picture->url = str_replace( 'wikisource/' . $lang, 'wikisource/' . $lang . '/thumb/', $picture->url ) . '/page' . $id[1] . '-400px-' . $title . '.jpg';
+			} elseif( strstr( $picture->url, '/sources/' ) ) {
+				$picture->url = str_replace( 'sources/', 'sources/thumb/', $picture->url ) . '/page' . $id[1] . '-400px-' . $title . '.jpg';
 			} else {
 				return new Picture();
 			}


### PR DESCRIPTION
generate cover thumb picture if 'ws-cover' is a local oldwikisource file - avoid `cURL error 3: <url> malformed` error, see: https://tools.wmflabs.org/wsexport/tool/book.php?lang=www&page=User%3AZdzislaw%2Ftest%C5%9B%C4%87+P02&format=epub-3