### PR TITLE
CLI: make credit generation optional

### DIFF
--- a/book/BookProvider.php
+++ b/book/BookProvider.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 class BookProvider {
 	protected $api = null;
 	protected $options = array(
-		'images' => true, 'fonts' => false, 'categories' => true
+		'images' => true, 'fonts' => false, 'categories' => true, 'credits' => true
 	);
 	private $creditUrl = 'http://tools.wmflabs.org/phetools/credits.py';
 
@@ -145,9 +145,15 @@ class BookProvider {
 			}
 			$book->chapters = $chapters;
 
-			$creditPromises = $this->startCredits( $book, $chapterTitles, $pageTitles, $pictures );
+			if ( $this->options['credits'] ) {
+				$creditPromises = $this->startCredits( $book, $chapterTitles, $pageTitles, $pictures );
+			}
+
 			$pictures = $this->getPicturesData( $pictures );
-			$book->credits = $this->finishCredit( $creditPromises );
+
+			if (!empty($creditPromises)) {
+				$book->credits = $this->finishCredit( $creditPromises );
+			}
 		}
 		$book->pictures = $pictures;
 

--- a/cli/book.php
+++ b/cli/book.php
@@ -8,6 +8,7 @@ if( !isset( $_SERVER['argc'] ) || $_SERVER['argc'] < 3 ) {
 } else {
 	$long_opts = array(
 		'lang::', 'title::', 'format:', 'path::', 'debug', 'tmpdir:',
+		'nocredits'
 	);
 
 	$lang = null;
@@ -15,6 +16,8 @@ if( !isset( $_SERVER['argc'] ) || $_SERVER['argc'] < 3 ) {
 	$format = 'epub';
 	$path = './';
 	$tempPath = sys_get_temp_dir();
+	$options = array();
+	$options['images'] = true;
 
 	$opts = getopt( 'l:t:f::p::d', $long_opts );
 	foreach( $opts as $opt => $value ) {
@@ -45,6 +48,9 @@ if( !isset( $_SERVER['argc'] ) || $_SERVER['argc'] < 3 ) {
 			case 'd':
 				error_reporting( E_STRICT | E_ALL );
 				break;
+			case 'nocredits':
+				$options['credits'] = false;
+				break;
 		}
 	}
 	if( !$lang or !$title or !$tempPath ) {
@@ -59,8 +65,6 @@ if( !isset( $_SERVER['argc'] ) || $_SERVER['argc'] < 3 ) {
 
 	try {
 		$api = new Api( $lang );
-		$options = array();
-		$options['images'] = true;
 		$provider = new BookProvider( $api, $options );
 		$data = $provider->get( $title );
 		if( $format == 'epub-2' ) {

--- a/cli/help/book.txt
+++ b/cli/help/book.txt
@@ -2,9 +2,10 @@ This command tool exports Wikisource books to ePub, ODT, or XHTML.
 
 Command line options are:
 
--l  --lang    Language code.  Required.
--t  --title   Wikisource page title, with spaces replaced by underscores.  Required.
--f  --format  Valid formats: epub-2, epub-3, xhtml, mobi, txt, rtf, pdf-a5, pdf-a4, pdf-letter  Default: epub-2
--p  --path    Output path.  Optional.  Defaults to the current directory.
--d  --debug   Verbose debugging output.  Optional.
-    --tmpdir  Directory in which to store temporary files.  Optional.
+-l  --lang      Language code.  Required.
+-t  --title     Wikisource page title, with spaces replaced by underscores.  Required.
+-f  --format    Valid formats: epub-2, epub-3, xhtml, mobi, txt, rtf, pdf-a5, pdf-a4, pdf-letter  Default: epub-2
+-p  --path      Output path.  Optional.  Defaults to the current directory.
+-d  --debug     Verbose debugging output.  Optional.
+    --tmpdir    Directory in which to store temporary files.  Optional.
+    --nocredits Don't include credits.  Optional, only use locally.


### PR DESCRIPTION
  Adding credits can add a lot of time to the book generation
  process (in the order of minutes) and is not always desirable, e.g. when experimenting
  with output formats or working on the tool itself.

