### PR TITLE
Add travis.yml for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+
+sudo: required
+dist: trusty
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq --force-yes calibre-bin
+  - phpenv install 5.6.13
+  - phpenv global 5.6.13
+  - php --version
+
+install:
+  - curl -sS https://getcomposer.org/installer | php
+  - php composer.phar install
+
+script:
+  - make test
+  - make integration-test


### PR DESCRIPTION
This automatically runs tests using [travis CI](https://travis-ci.org). You'll need to enable it on the website, they provide free services for open source projects.

See https://travis-ci.org/jberkel/tool for an example run.