### PR TITLE
include fonts in .css (even when not embedded in ePub [fixes #26])

### DIFF
--- a/book/FontProvider.php
+++ b/book/FontProvider.php
@@ -72,7 +72,6 @@ class FontProvider {
 		if ( isset( $font['otf']['RBI'] ) ) {
 			$css .= '@font-face { font-family: "' . $font['name'] . '"; font-weight: bold; font-style: italic; src: url("' . $basePath . $font['name'] . 'RBI.otf"); }' . "\n";
 		}
-		$css .= 'body { font-family: ' . $font['name'] . ', Arial, serif; }' . "\n\n";
 
 		return $css;
 	}

--- a/book/mediawiki.css
+++ b/book/mediawiki.css
@@ -1,4 +1,5 @@
 body {
+	font-family: FreeSerif, LinuxLibertine, Arial, serif;
 	line-height: 1.2;
 }
 


### PR DESCRIPTION
@Tpt, this pull request adds typefaces in the stylesheet file, as described the issue.

Having the typefaces even when not embedded will help, if the user has installed on the system.