### PR TITLE
add FreeSerif and LinuxLibertine (if and only if previously defined)

### DIFF
--- a/book/FontProvider.php
+++ b/book/FontProvider.php
@@ -15,11 +15,11 @@ class FontProvider {
 	 */
 	protected static $data = [
 		'freeserif' => [
-			'name' => 'f_s', 'label' => 'Free Serif', 'otf' => [
+			'name' => 'wse_FreeSerif', 'label' => 'Free Serif', 'otf' => [
 				'R' => 'FreeSerif.otf', 'RB' => 'FreeSerifBold.otf', 'RBI' => 'FreeSerifBoldItalic.otf', 'RI' => 'FreeSerifItalic.otf'
 			]
 		], 'linuxlibertine' => [
-			'name' => 'l_l', 'label' => 'Linux Libertine', 'otf' => [
+			'name' => 'wse_LinuxLibertine', 'label' => 'Linux Libertine', 'otf' => [
 				'R' => 'LinLibertine_R.otf', 'RB' => 'LinLibertine_RB.otf', 'RBI' => 'LinLibertine_RBI.otf', 'RI' => 'LinLibertine_RI.otf'
 			]
 		]

--- a/book/FontProvider.php
+++ b/book/FontProvider.php
@@ -15,11 +15,11 @@ class FontProvider {
 	 */
 	protected static $data = [
 		'freeserif' => [
-			'name' => 'FreeSerif', 'label' => 'Free Serif', 'otf' => [
+			'name' => 'f_s', 'label' => 'Free Serif', 'otf' => [
 				'R' => 'FreeSerif.otf', 'RB' => 'FreeSerifBold.otf', 'RBI' => 'FreeSerifBoldItalic.otf', 'RI' => 'FreeSerifItalic.otf'
 			]
 		], 'linuxlibertine' => [
-			'name' => 'LinuxLibertine', 'label' => 'Linux Libertine', 'otf' => [
+			'name' => 'l_l', 'label' => 'Linux Libertine', 'otf' => [
 				'R' => 'LinLibertine_R.otf', 'RB' => 'LinLibertine_RB.otf', 'RBI' => 'LinLibertine_RBI.otf', 'RI' => 'LinLibertine_RI.otf'
 			]
 		]
@@ -72,7 +72,6 @@ class FontProvider {
 		if ( isset( $font['otf']['RBI'] ) ) {
 			$css .= '@font-face { font-family: "' . $font['name'] . '"; font-weight: bold; font-style: italic; src: url("' . $basePath . $font['name'] . 'RBI.otf"); }' . "\n";
 		}
-		$css .= 'body { font-family: ' . $font['name'] . ', Arial, serif; }' . "\n\n";
 
 		return $css;
 	}

--- a/book/mediawiki.css
+++ b/book/mediawiki.css
@@ -1,4 +1,5 @@
 body {
+	font-family: f_s, l_l, serif;
 	line-height: 1.2;
 }
 

--- a/book/mediawiki.css
+++ b/book/mediawiki.css
@@ -1,5 +1,5 @@
 body {
-	font-family: f_s, l_l, serif;
+	font-family: "wse_FreeSerif", "wse_LinuxLibertine", serif;
 	line-height: 1.2;
 }
 


### PR DESCRIPTION
@Tpt, this is a better way to have the fonts in the ePub.

It doesn’t change the default typeface, since either `f_s` or `l_l` have to be defined first with `@font-face`.

Any user can make use of the typefaces defining them.

I hope this is better now and can be merged.