### PR TITLE
Check if filename is set

### DIFF
--- a/book/formats/ConvertGenerator.php
+++ b/book/formats/ConvertGenerator.php
@@ -105,7 +105,9 @@ class ConvertGenerator implements FormatGenerator {
 			rename( $epubFileName, $persistentEpubFileName );
 			$this->convert( $persistentEpubFileName, $outputFileName );
 		} finally {
-			removeFile( $persistentEpubFileName );
+			if (isset($persistentEpubFileName)) {
+				removeFile($persistentEpubFileName);
+			}
 		}
 
 		return $outputFileName;

--- a/book/formats/ConvertGenerator.php
+++ b/book/formats/ConvertGenerator.php
@@ -105,8 +105,8 @@ class ConvertGenerator implements FormatGenerator {
 			rename( $epubFileName, $persistentEpubFileName );
 			$this->convert( $persistentEpubFileName, $outputFileName );
 		} finally {
-			if (isset($persistentEpubFileName)) {
-				removeFile($persistentEpubFileName);
+			if ( isset( $persistentEpubFileName ) ) {
+				removeFile( $persistentEpubFileName );
 			}
 		}
 


### PR DESCRIPTION
`createEpub` can throw an exception, in this case, `$persistentEpubFileName` is not set, so `removeFile('')` is called and tries to remove the current directory. (yes, it fails because `rm` does not delete a directory, without `-Rf`)