### PR TITLE
Use 'href' instead of 'title' as the source of chapter links

### DIFF
--- a/book/PageParser.php
+++ b/book/PageParser.php
@@ -40,17 +40,21 @@ class PageParser {
 	}
 
 	/**
-	 * return the list of the chapters with the summary if it exist.
+	 * Return the list of the chapters (based on the ws-summary HTML if it exists, otherwise via all internal links).
+	 * @param string[] $pageList Array of page titles.
+	 * @param string[] $namespaces Array of all localized namespace names of the current wiki.
 	 * @return Page[]
-	 * TODO retrive only main namespace pages ?
 	 */
 	public function getChaptersList( $pageList, $namespaces ) {
 		$list = $this->xPath->query( '//*[@id="ws-summary" or contains(@class,"ws-summary")]/descendant::a[not(contains(@href,"action=edit") or contains(@class,"extiw") or contains(@class,"external") or contains(@class,"internal") or contains(@class,"image"))]' );
 		$chapters = [];
 		/** @var DOMElement $link */
 		foreach ( $list as $link ) {
-			$title = str_replace( ' ', '_', $link->getAttribute( 'title' ) );
+			// Extract the page title (including namespace) from the relative URL in the link (via a dummy URL).
+			$urlParts = parse_url( 'http://example.com' . $link->getAttribute( 'href' ) );
+			$title = urldecode( substr( $urlParts['path'], strlen( '/wiki/' ) ) );
 			$parts = explode( ':', $title );
+			// Include the chapter if it's not already present and is a main-namespace page.
 			if ( $title != '' && !in_array( $title, $pageList ) && !in_array( $parts[0], $namespaces ) ) {
 				$chapter = new Page();
 				$chapter->title = $title;

--- a/tests/book/PageParserTest.php
+++ b/tests/book/PageParserTest.php
@@ -18,6 +18,8 @@ class PageParserTest extends PHPUnit\Framework\TestCase {
 	public function testGetChaptersList() {
 		$chapterList = $this->pageParser->getChaptersList( [], [] );
 		$this->assertCount( 14, $chapterList );
+		$this->assertEquals( "Tales_of_Unrest/Author's_Note", $chapterList[0]->title );
+		$this->assertEquals( "Karain/Chapter_V", $chapterList[6]->title );
 	}
 
 	public function testGetFullChaptersList() {

--- a/tests/book/fixtures/Tales_of_Unrest/Navigation.html
+++ b/tests/book/fixtures/Tales_of_Unrest/Navigation.html
@@ -45,8 +45,8 @@
                 <li><a href="/wiki/Karain/Chapter_I" title="Karain/Chapter I">Chapter I</a></li>
                 <li><a href="/wiki/Karain/Chapter_II" title="Karain/Chapter II">Chapter II</a></li>
                 <li><a href="/wiki/Karain/Chapter_III" title="Karain/Chapter III">Chapter III</a></li>
-                <li><a href="/wiki/Karain/Chapter_IV" title="Karain/Chapter IV">Chapter IV</a></li>
-                <li><a href="/wiki/Karain/Chapter_V" title="Karain/Chapter V">Chapter V</a></li>
+                <li><a href="/wiki/Karain/Chapter_IV" title="Karain/Chapter IV - with a title that doesn't match">Chapter IV</a></li>
+                <li><a href="/wiki/Karain/Chapter_V#test-fragment" title="Karain/Chapter V">Chapter V</a> (with a fragment test)</li>
                 <li><a href="/wiki/Karain/Chapter_VI" title="Karain/Chapter VI">Chapter VI</a></li>
             </ul>
         </li>

--- a/utils/Api.php
+++ b/utils/Api.php
@@ -173,14 +173,14 @@ class Api {
 
 	private function parseGetPageResponse( $response ) {
 		foreach ( $response['query']['pages'] as $page ) {
+			$title = $page['title'];
 			if ( isset( $page['revisions'] ) ) {
 				foreach ( $page['revisions'] as $revision ) {
-					return getXhtmlFromContent( $this->lang, $revision['*'], $page['title'] );
+					return getXhtmlFromContent( $this->lang, $revision['*'], $title );
 				}
 			}
 		}
-
-		throw new HttpException( 'Page revision not found', 404 );
+		throw new HttpException( "Page revision not found for: $title", 404 );
 	}
 
 	/**


### PR DESCRIPTION
Change the chapter-finding method to use the href value of
anchors rather than the title, because linked images can set
different title text.

Bug: #146