### PR TITLE
Fix "Header may not contain more than a single header" warning

### DIFF
--- a/http/book.php
+++ b/http/book.php
@@ -52,8 +52,9 @@ try {
 	}
 } catch ( Exception $exception ) {
 	if ( $exception instanceof HttpException ) {
-		header( 'HTTP/1.1 ' . $exception->getCode() . ' ' . $exception->getMessage() );
+		$parts = preg_split( '/[\r\n]+/', $exception->getMessage(), 2 );
+		header( 'HTTP/1.1 ' . $exception->getCode() . ' ' . $parts[0] );
 	}
-	$error = htmlspecialchars( $exception->getMessage() );
+	$error = nl2br( htmlspecialchars( $exception->getMessage() ) );
 	include 'templates/book.php';
 }


### PR DESCRIPTION
Looks like some exceptions had multiline messages - use the first line
in headers. Additionally, display such errors on multiple lines on screen.

Bug: https://phabricator.wikimedia.org/T221333