### PR TITLE
Double PHP memory limit

### DIFF
--- a/http/.user.ini
+++ b/http/.user.ini
@@ -1,0 +1,4 @@
+; This file contains local php.ini overrides.
+; See https://wikitech.wikimedia.org/wiki/Help:Toolforge/Web/Lighttpd#PHP
+; for documentation.
+memory_limit = 256M


### PR DESCRIPTION
While it's not a proper fix for #44, it improves the situation while
we're investigating it further. In any case, 256M is not an unreasonable
limit.