### PR TITLE
Store images on disk while generating books

### DIFF
--- a/book/Book.php
+++ b/book/Book.php
@@ -46,7 +46,7 @@ class Book extends Page {
 
 	/**
 	 * pictures included in the page
-	 * @type array
+	 * @var Picture[]
 	 */
 	public $pictures = [];
 

--- a/book/FileCleaner.php
+++ b/book/FileCleaner.php
@@ -2,14 +2,22 @@
 
 class FileCleaner {
 
-	public static function cleanFile( $content, $mimetype ) {
-		if ( $mimetype === 'image/svg+xml' ) {
+	/**
+	 * @param string $mimetype
+	 * @return bool whether files with the given MIME type need cleaning up
+	 */
+	public static function needsCleaning( string $mimetype ): bool {
+		return $mimetype === 'image/svg+xml';
+	}
+
+	public static function cleanFile( string $content, string $mimetype ): string {
+		if ( self::needsCleaning( $mimetype ) ) {
 			return self::cleanSVG( $content );
 		}
 		return $content;
 	}
 
-	private static function cleanSVG( $content ) {
+	private static function cleanSVG( string $content ): string {
 		return preg_replace( '/<!DOCTYPE[^>[]*(\[[^]]*\])?>/', '', $content );
 	}
 }

--- a/book/Picture.php
+++ b/book/Picture.php
@@ -34,8 +34,36 @@ class Picture {
 	public $mimetype = '';
 
 	/**
-	 * content of the picture
+	 * temporary file with this picture's content
 	 * @type string
 	 */
-	public $content = null;
+	public $tempFile = null;
+
+	public $content;
+
+	/**
+	 * Saves this picture's data to a zip archive, sanitizing if needed
+	 * If the file does't need sanitization, it's not read to save memory
+	 *
+	 * @param ZipArchive $zip
+	 * @param string $localName
+	 */
+	public function saveToZip( ZipArchive $zip, string $localName ) {
+		if ( FileCleaner::needsCleaning( $this->mimetype ) ) {
+			$content = file_get_contents( $this->tempFile );
+			$content = FileCleaner::cleanFile( $content, $this->mimetype );
+			$zip->addFromString( $localName, $content );
+		} else {
+			$zip->addFile( $this->tempFile, $localName );
+		}
+	}
+
+	/**
+	 * makes sure that temporary file gets deleted
+	 */
+	public function __destruct() {
+		if ( $this->tempFile && file_exists( $this->tempFile ) ) {
+			unlink( $this->tempFile );
+		}
+	}
 }

--- a/book/formats/EpubGenerator.php
+++ b/book/formats/EpubGenerator.php
@@ -81,7 +81,7 @@ abstract class EpubGenerator implements FormatGenerator {
 			}
 		}
 		foreach ( $book->pictures as $picture ) {
-			$zip->addFromString( 'OPS/images/' . $picture->title, $picture->content );
+			$picture->saveToZip( $zip, 'OPS/images/' . $picture->title );
 		}
 		$zip->addFromString( 'OPS/main.css', $css );
 		$this->addContent( $book, $zip );

--- a/cli/cleanup.sh
+++ b/cli/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run periodically via cron to delete temporary files
+
+DIR=$(dirname $(dirname $0))
+
+find "${DIR}/temp" -name "ws-*" -mtime +1 -delete
+
+find "${DIR}/temp" -name "img-*" -mtime +1 -delete

--- a/utils/Api.php
+++ b/utils/Api.php
@@ -84,6 +84,18 @@ class Api {
 	}
 
 	/**
+	 * @param string $url
+	 * @param array $options
+	 * @return PromiseInterface
+	 */
+	public function createAsyncRequest( string $url, array $options = [] ): PromiseInterface {
+		return $this->client->getAsync(
+			$url,
+			$options
+		);
+	}
+
+	/**
 	 * @param Request[] $requests
 	 * @param array $options
 	 * @return PromiseInterface

--- a/utils/utils.php
+++ b/utils/utils.php
@@ -58,24 +58,19 @@ function getFile( $file ) {
 /**
  * Get mimetype of a file, using finfo if its available, or mime_magic.
  *
- * @param string $contents a buffer containing the contents of the file
- * @return string|bool mime type on success or false on failure
+ * @param string $filename
+ * @return string|false mime type on success or false on failure
  */
-function getMimeType( $contents ) {
+function getMimeType( string $filename ) {
 	if ( class_exists( 'finfo', false ) ) {
 		$finfoOpt = defined( 'FILEINFO_MIME_TYPE' ) ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
 		$info = new finfo( $finfoOpt );
 		if ( $info ) {
-			return $info->buffer( $contents );
+			return $info->file( $filename );
 		}
 	}
 	if ( ini_get( 'mime_magic.magicfile' ) && function_exists( 'mime_content_type' ) ) {
-		$filename = tempnam( sys_get_temp_dir(), 'wsf' );
-		file_put_contents( $filename, $contents );
-		$ret = mime_content_type( $filename );
-		removeFile( $filename );
-
-		return $ret;
+		return mime_content_type( $filename );
 	}
 
 	return false;


### PR DESCRIPTION
When testing on https://fr.wikisource.org/wiki/Voyage_au_centre_de_la_Terre
this halved peak memory usage from 42M to 22M. Even the old version is apparently
able to fit in memory, however - so the mystery remains. After deploying this
change, we need to see how it performs because while on my laptop there's no
noticeable performance degradation, this is not necessarily the case on NFS.

References #44
Bug: https://phabricator.wikimedia.org/T221493