### PR TITLE
Move config to separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ temp/*
 !temp/.gitkeep
 vendor/*
 composer.phar
+config.php

--- a/cli/book.php
+++ b/cli/book.php
@@ -1,14 +1,10 @@
 #!/usr/bin/php
 <?php
 
-$basePath = realpath( __DIR__ . '/..' );
 global $wsexportConfig;
+$wsexportConfig = require_once dirname( __DIR__ ) . '/config.php';
 
-$wsexportConfig = [
-	'basePath' => $basePath, 'stat' => false, 'tempPath' => $basePath . '/temp', 'debug' => false
-];
-
-include_once $basePath . '/book/init.php';
+include_once $wsexportConfig['basePath'] . '/book/init.php';
 
 function parseCommandLine() {
 	global $wsexportConfig;

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,15 @@
 		],
 		"fix": [
 			"phpcbf"
+		],
+		"mkconfig": [
+			"php -r \"file_exists('config.php') || copy('config.dist.php', 'config.php');\""
+		],
+		"post-install-cmd": [
+			"@mkconfig"
+		],
+		"post-update-cmd": [
+			"@mkconfig"
 		]
 	}
 }

--- a/config.dist.php
+++ b/config.dist.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+	'debug' => false,
+	'stat' => PHP_SAPI !== 'cli',
+	'basePath' => __DIR__,
+	'tempPath' => __DIR__ . '/temp/',
+	// 'ebook-convert' => '',
+];

--- a/http/book.php
+++ b/http/book.php
@@ -1,9 +1,9 @@
 <?php
-$wsexportConfig = [
-	'basePath' => '..', 'tempPath' => __DIR__ . '/../temp', 'stat' => true
-];
 
-include_once __DIR__ . '/../book/init.php';
+global $wsexportConfig;
+$wsexportConfig = require_once dirname( __DIR__ ) . '/config.php';
+
+include_once $wsexportConfig['basePath'] . '/book/init.php';
 
 $api = new Api();
 $title = isset( $_GET['page'] ) ? trim( htmlspecialchars( urldecode( $_GET['page'] ) ) ) : '';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,4 +23,5 @@
 	<file>.</file>
 	<exclude-pattern>temp/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
+	<exclude-pattern>config.php</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Move the $wsexportConfig global to a separate config.php file
and load it for the web and CLI entry points.

As this new file is not optional, also add a composer script to
create it at install and update time.

Bug: T222330