### PR TITLE
Add exception logging

### DIFF
--- a/tests/http/BookTest.php
+++ b/tests/http/BookTest.php
@@ -52,6 +52,7 @@ class BookTest extends \PHPUnit\Framework\TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function testGetInvalidFormatDisplaysError() {
+		define( 'IN_UNIT_TEST', true );
 		$_GET['page'] = 'xxx';
 		$_GET['format'] = 'xxx';
 		$this->expectOutputRegex( '/' . preg_quote( "The file format 'xxx' is unknown." ) . '/' );

--- a/utils/utils.php
+++ b/utils/utils.php
@@ -184,3 +184,16 @@ function removeFile( $fileName ) {
 	}
 	return $result === 0;
 }
+
+/**
+ * Returns a string representation of an exception useful for logging
+ *
+ * @param Exception $ex
+ * @return string
+ */
+function formatException( Exception $ex ): string {
+	$date = date( DATE_RFC3339 );
+	$class = get_class( $ex );
+
+	return "$date: $class {$ex->getMessage()}\n{$ex->getTraceAsString()}\n";
+}


### PR DESCRIPTION
I initially considered not logging some HttpExcpetions as they're
"business as usual", but decided for now that having everything
logged is valuable and we can exclude some excpetions later if
they will be too noisy.

Bug: T221335