### PR TITLE
Move logs.sqlite to the http directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ temp/*
 vendor/*
 composer.phar
 config.php
+*.sqlite
+

--- a/book/CreationLog.php
+++ b/book/CreationLog.php
@@ -56,8 +56,8 @@ class CreationLog {
 
 	private static function getDbPath() {
 		global $wsexportConfig;
-		if ( $wsexportConfig['stat'] && $wsexportConfig['tempPath'] ) {
-			return 'sqlite:' . $wsexportConfig['tempPath'] . '/logs.sqlite';
+		if ( $wsexportConfig['stat'] && $wsexportConfig['logDatabase'] ) {
+			return 'sqlite:' . $wsexportConfig['logDatabase'];
 		} else {
 			return 'sqlite::memory:';
 		}

--- a/config.dist.php
+++ b/config.dist.php
@@ -5,5 +5,6 @@ return [
 	'stat' => PHP_SAPI !== 'cli',
 	'basePath' => __DIR__,
 	'tempPath' => __DIR__ . '/temp/',
+	'logDatabase' => __DIR__ . '/http/logs.sqlite'
 	// 'ebook-convert' => '',
 ];

--- a/http/stat.php
+++ b/http/stat.php
@@ -1,7 +1,7 @@
 <?php
-$wsexportConfig = [
-	'basePath' => '..', 'tempPath' => '../temp', 'stat' => true
-];
+
+global $wsexportConfig;
+$wsexportConfig = require_once dirname( __DIR__ ) . '/config.php';
 
 function normalizeFormat( $format ) {
 	$parts = explode( '-', $format );


### PR DESCRIPTION
Add a new config variable 'logDatabase' that specifies the
full filesystem path to the logs.sqlite file in which to store
access statistics.

Also switch to using the new config.php file in stats.php so
that this new variable need only be set in one place.

Ref: #168