### PR TITLE
Rework cache operation

### DIFF
--- a/bin/cleanup.sh
+++ b/bin/cleanup.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Run periodically via cron to delete temporary files
-
-DIR=$(dirname $(dirname $0))
-
-find "${DIR}/temp" -name "ws-*" -mtime +1 -delete
-
-find "${DIR}/temp" -name "img-*" -mtime +1 -delete

--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -212,9 +212,9 @@ class BookProvider {
 	protected function getPicturesData( array $pictures ) {
 		$promises = array_map(
 			function ( Picture $picture ) {
-				global $wsexportConfig;
+				$cache = FileCache::singleton();
 
-				$picture->tempFile = tempnam( $wsexportConfig['tempPath'], 'pic-' );
+				$picture->tempFile = tempnam( $cache->getDirectory(), 'pic-' );
 				$options = [ 'sink' => $picture->tempFile ];
 				return $this->api->createAsyncRequest( $picture->url, $options );
 			},

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App;
+
+use Exception;
+
+/**
+ * Handles this tool's disk cache, maintaining a separate directory and cleaning files from it
+ */
+class FileCache {
+	// Cleanup temporary storage at the end of 5% of requests
+	private const CLEANUP_RATE = 5;
+
+	// Delete files after this amount of time in seconds
+	private const CACHE_DURATION = 24 * 60 * 60;
+
+	/** @var string Tool-specific temporary directory */
+	private $dir;
+
+	/** @var FileCache */
+	private static $instance;
+
+	/**
+	 * @param string $path Directory for temp files
+	 */
+	private function __construct( string $path ) {
+		$this->dir = $this->makePrivateDirectory( $path );
+
+		// Randomly clean up the cache
+		if ( mt_rand( 0, 100 ) <= self::CLEANUP_RATE ) {
+			register_shutdown_function( function () {
+				$this->cleanup();
+			} );
+		}
+	}
+
+	/**
+	 * Returns a global instance of this class
+	 * @return FileCache
+	 */
+	public static function singleton(): FileCache {
+		global $wsexportConfig;
+
+		if ( !self::$instance ) {
+			self::$instance = new FileCache( $wsexportConfig['tempPath'] );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @return string Directory for temporary files
+	 */
+	public function getDirectory(): string {
+		return $this->dir;
+	}
+
+	/**
+	 * Creates a tool-specific temporary directory with specific permissions
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	private function makePrivateDirectory( string $path ): string {
+		// Use username in the path. The tool needs its own directory so that it knows which
+		// files to garbage collect. Can't just use the hardcoded name because
+		// wsexport and wsexport-test might end up on the same node, stepping on each other's toes.
+		$user = get_current_user();
+		// Remove leading "tools." present if running on labs
+		$user = preg_replace( '/^tools\./', '', $user );
+		$dir = rtrim( $path, '/' ) . '/' . $user;
+
+		// Guard against realpth() returning false sometimes
+		$dir = realpath( $dir ) ?: $dir;
+
+		if ( !is_dir( $dir ) ) {
+			if ( !mkdir( $dir, 0755 ) ) {
+				throw new Exception( "Couldn't create temporary directory $dir" );
+			}
+		}
+
+		return $dir;
+	}
+
+	/**
+	 * Cleans up file cache, deleting old files
+	 */
+	private function cleanup(): void {
+		foreach ( glob( $this->dir . '/*.*' ) as $fileName ) {
+			$this->checkFile( $fileName );
+		}
+	}
+
+	/**
+	 * Checks whether the given file is present locally and not stale.
+	 * Deletes the file if it's stale.
+	 * @param string $fileName
+	 */
+	protected function checkFile( string $fileName ): void {
+		// phpcs:disable Generic.PHP.NoSilencedErrors.Discouraged
+		$stat = @stat( $fileName );
+		// phpcs:enable
+		// Failed stat means something went wrong, directories are used for per-wiki metadata
+		if ( !$stat || is_dir( $fileName ) || $fileName === '.gitkeep' ) {
+			return;
+		}
+		if ( $stat['mtime'] + self::CACHE_DURATION < time() ) {
+			unlink( $fileName );
+		}
+	}
+}

--- a/src/Generator/AtomGenerator.php
+++ b/src/Generator/AtomGenerator.php
@@ -58,7 +58,7 @@ class AtomGenerator implements FormatGenerator {
 		$this->appendNamespaces( $entry );
 		$dom->appendChild( $entry );
 
-		$fileName = Util::buildTemporaryFileName( $book->title, 'atom', true );
+		$fileName = Util::buildTemporaryFileName( $book->title, 'atom' );
 		$dom->save( $fileName );
 		return $fileName;
 	}

--- a/src/Generator/EpubGenerator.php
+++ b/src/Generator/EpubGenerator.php
@@ -59,7 +59,7 @@ abstract class EpubGenerator implements FormatGenerator {
 		$wsUrl = Util::wikisourceUrl( $book->lang, $book->title );
 		$cleaner = new BookCleanerEpub( $this->getVersion() );
 		$cleaner->clean( $book, Util::wikisourceUrl( $book->lang ) );
-		$fileName = Util::buildTemporaryFileName( $book->title, 'epub', true );
+		$fileName = Util::buildTemporaryFileName( $book->title, 'epub' );
 		$zip = $this->createZipFile( $fileName );
 		$zip->addFromString( 'META-INF/container.xml', $this->getXmlContainer() );
 		$zip->addFromString( 'OPS/content.opf', $this->getOpfContent( $book, $wsUrl ) );

--- a/src/Refresh.php
+++ b/src/Refresh.php
@@ -98,7 +98,8 @@ class Refresh {
 	}
 
 	protected function getTempFileName( $name ) {
-		global $wsexportConfig;
-		return $wsexportConfig['tempPath'] . '/' . $this->api->lang . '/' . $name;
+		$cache = FileCache::singleton();
+
+		return $cache->getDirectory() . '/' . $this->api->lang . '/' . $name;
 	}
 }

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -2,6 +2,7 @@
 
 namespace App\Util;
 
+use App\FileCache;
 use App\Refresh;
 use DOMElement;
 use DOMXPath;
@@ -109,8 +110,8 @@ class Util {
 	}
 
 	public static function getTempFile( $lang, $name ) {
-		global $wsexportConfig;
-		$path = $wsexportConfig['tempPath'] . '/' . $lang . '/' . $name;
+		$cache = FileCache::singleton();
+		$path = $cache->getDirectory() . '/' . $lang . '/' . $name;
 		if ( !file_exists( $path ) ) {
 			$refresh = new Refresh( new Api( $lang ) );
 			$refresh->refresh();
@@ -169,16 +170,11 @@ class Util {
 	 *
 	 * @param string $title
 	 * @param string $extension
-	 * @param bool $systemTemp Use the system /tmp directory
 	 * @return string
 	 */
-	public static function buildTemporaryFileName( $title, $extension, $systemTemp = false ) {
-		if ( $systemTemp ) {
-			$directory = sys_get_temp_dir();
-		} else {
-			global $wsexportConfig;
-			$directory = realpath( $wsexportConfig['tempPath'] );
-		}
+	public static function buildTemporaryFileName( $title, $extension ) {
+		$cache = FileCache::singleton();
+		$directory = $cache->getDirectory();
 
 		for ( $i = 0; $i < 100; $i++ ) {
 			$path = $directory . '/' . 'ws-' . static::encodeString( $title ) . '-' . getmypid() . rand() . '.' . $extension;


### PR DESCRIPTION
Currently, wsexport attempts to clean after itself, e.g. in
Picture::__destruct(), however this doesn't protect us from
some types of fatal errors, PHP segfaults and programmer
mistakes. Since we want to keep the temporary files in local
/tmp to make I/O fast, we can't clean them up via a gronjob,
as the webservice can be run on different lighttpd VMs.

This patch introduces a new class FileCache and makes
everything use it:
* It maintains a per-tool directory under tempPath
  (which is now intended to point to /tmp on Toolforge).
* Cleans this directory of old files on 5% of requests.
* Unifies all places using temporary files/directories, making
  it use the new class. Util::buildTemporaryFileName() can't
  override this now (and thus it can't forget files in places
  FileCache doesn't clean).

Bug: https://phabricator.wikimedia.org/T166337