### PR TITLE
Universal bootstrap for all entrypoints

### DIFF
--- a/bin/book.php
+++ b/bin/book.php
@@ -1,13 +1,10 @@
 #!/usr/bin/php
 <?php
 
-require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/bootstrap.php';
 
 use App\BookCreator;
 use App\Exception\WSExportInvalidArgumentException;
-
-global $wsexportConfig;
-$wsexportConfig = require_once dirname( __DIR__ ) . '/config.php';
 
 function parseCommandLine() {
 	global $wsexportConfig;

--- a/bin/opds.php
+++ b/bin/opds.php
@@ -6,13 +6,7 @@ if ( count( $argv ) < 2 ) {
 	exit( 1 );
 }
 
-$basePath = realpath( __DIR__ . '/..' );
-$tempPath = sys_get_temp_dir();
-
-$wsexportConfig = [
-	'basePath' => $basePath, 'tempPath' => $tempPath, 'stat' => true
-];
-require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/bootstrap.php';
 
 use App\BookProvider;
 use App\OpdsBuilder;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is loaded by every entry-point to the application: web, cli, and test.
+ * Note that during tests it can at times be loaded more than once,
+ * which is why we conditionally load the config here.
+ *
+ * @file
+ */
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+global $wsexportConfig;
+if ( !is_array( $wsexportConfig ) ) {
+	// Use 'require' rather than 'require_once' so that we can re-read config.php when required.
+	$wsexportConfig = require __DIR__ . '/config.php';
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
          backupGlobals="true"
          colors="true"
-         bootstrap="tests/bootstrap.php">
+         bootstrap="bootstrap.php">
 
     <testsuites>
         <testsuite name="Project Test Suite">

--- a/public/book.php
+++ b/public/book.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/bootstrap.php';
 
 use App\BookCreator;
 use App\CreationLog;
@@ -10,9 +10,6 @@ use App\Refresh;
 use App\Util\Api;
 use App\Util\Util;
 use GuzzleHttp\Exception\RequestException;
-
-global $wsexportConfig;
-$wsexportConfig = require_once dirname( __DIR__ ) . '/config.php';
 
 $api = new Api();
 $title = isset( $_GET['page'] ) ? trim( htmlspecialchars( urldecode( $_GET['page'] ) ) ) : '';

--- a/public/stat.php
+++ b/public/stat.php
@@ -1,11 +1,8 @@
 <?php
 
-require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/bootstrap.php';
 
 use App\CreationLog;
-
-global $wsexportConfig;
-$wsexportConfig = require_once dirname( __DIR__ ) . '/config.php';
 
 function normalizeFormat( $format ) {
 	$parts = explode( '-', $format );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,0 @@
-<?php
-$basePath = realpath( __DIR__ . '/..' );
-
-global $wsexportConfig;
-$wsexportConfig = [
-	'basePath' => $basePath, 'stat' => false, 'tempPath' => sys_get_temp_dir(), 'debug' => false
-];
-
-require_once dirname( __DIR__ ) . '/vendor/autoload.php';


### PR DESCRIPTION
There are five entrypoints to this application: two web, two CLI,
and one test. The test one loads the others sometimes, and in
doing can have its config clobbered. This change moves all
config-loading to a single file, bootstrap.php, which can then
avoid double-loading.