### PR TITLE
Fully-qualify URLs in About page, and remove toc

### DIFF
--- a/src/Generator/Epub3Generator.php
+++ b/src/Generator/Epub3Generator.php
@@ -172,9 +172,6 @@ class Epub3Generator extends EpubGenerator {
 					   <nav epub:type="landmarks" id="guide">
 						  <ol>
 							    <li>
-								  <a epub:type="toc" href="#toc">Table of Contents</a>
-							    </li>
-							    <li>
 								  <a epub:type="bodymatter" href="' . $book->title . '.xhtml">' . htmlspecialchars( $book->name, ENT_QUOTES ) . '</a>
 							    </li>
 							    <li>

--- a/src/Refresh.php
+++ b/src/Refresh.php
@@ -70,7 +70,11 @@ class Refresh {
 			$document->loadXML( $content );
 			$parser = new PageParser( $document );
 			$document = $parser->getContent( true );
-			$this->setTempFileContent( 'about.xhtml', str_replace( 'href="//', 'href="https://', $document->saveXML() ) );
+			// Add https to protocol-relative links.
+			$aboutHtml = str_replace( 'href="//', 'href="https://', $document->saveXML() );
+			// Fully qualify unqualified links.
+			$aboutHtml = str_replace( 'href="/', 'href="https://' . $this->api->domainName . '/', $aboutHtml );
+			$this->setTempFileContent( 'about.xhtml', $aboutHtml );
 		}
 	}
 


### PR DESCRIPTION
This fixes two things that epubcheck was complaining about:

1. "Found a reference to a resource that is not a spine item."
   with the ToC being referenced with `href="#toc"`, which isn't
   permitted. We can't link directly to the actual content-ToC
   because that's not in a standard place in Wikisource works.
2. "Referenced resource could not be found in the EPUB." with
   links in the About page that are not fully qualified. Fixed
   by adding the protocol and domain name.