### PR TITLE
Add recent popular books to front page

### DIFF
--- a/public/templates/book.php
+++ b/public/templates/book.php
@@ -1,81 +1,99 @@
 <?php
 
+use App\CreationLog;
 use App\FontProvider;
 use App\GeneratorSelector;
 use App\Util\Api;
 
 include 'header.php';
 ?>
-<form method="get" action="book.php" role="form" class="form-horizontal">
-	<fieldset>
-		<legend>Export a file</legend>
-		<div class="form-group">
-			<label for="lang" class="col-lg-2 control-label">Language code</label>
+<div class="row">
+	<form method="get" action="book.php" role="form" class="form-horizontal col-md-9">
+		<fieldset>
+			<legend>Export a file</legend>
+			<div class="form-group">
+				<label for="lang" class="col-lg-2 control-label">Language code</label>
 
-			<div class="col-lg-10">
-				<input name="lang" id="lang" type="text" size="3" maxlength="20" required="required"
-					   value="<?php echo Api::getHttpLang(); ?>" class="form-control input-mini"/>
-				<span class="help-block">Language code of Wikisource domain, like en or fr</span>
+				<div class="col-lg-10">
+					<input name="lang" id="lang" type="text" size="3" maxlength="20" required="required"
+						   value="<?php echo Api::getHttpLang(); ?>" class="form-control input-mini"/>
+					<span class="help-block">Language code of Wikisource domain, like en or fr</span>
+				</div>
 			</div>
-		</div>
-		<div class="form-group">
-			<label for="page" class="col-lg-2 control-label">Title of the page</label>
+			<div class="form-group">
+				<label for="page" class="col-lg-2 control-label">Title of the page</label>
 
-			<div class="col-lg-10">
-				<input name="page" id="page" type="text" size="30" required="required" class="form-control"
-					   value="<?php echo $title; ?>"/>
-				<span class="help-block">Name of the mainpage of the book in Wikisource</span>
+				<div class="col-lg-10">
+					<input name="page" id="page" type="text" size="30" required="required" class="form-control"
+						   value="<?php echo $title; ?>"/>
+					<span class="help-block">Name of the mainpage of the book in Wikisource</span>
+				</div>
 			</div>
-		</div>
-		<div class="form-group">
-			<label for="format" class="col-lg-2 control-label">File format</label>
+			<div class="form-group">
+				<label for="format" class="col-lg-2 control-label">File format</label>
 
-			<div class="col-lg-10">
-				<select id="format" name="format" class="form-control">
-					<?php foreach ( GeneratorSelector::$formats as $key => $label ) {
-						echo '<option value="' . $key . '"';
-						if ( $format === $key ) {
-							echo ' selected="selected"';
+				<div class="col-lg-10">
+					<select id="format" name="format" class="form-control">
+						<?php foreach ( GeneratorSelector::$formats as $key => $label ) {
+							echo '<option value="' . $key . '"';
+							if ( $format === $key ) {
+								echo ' selected="selected"';
+							}
+							echo '>' . $label . '</option>';
+			   } ?>
+					</select>
+					<span class="help-inline"></span>
+				</div>
+			</div>
+			<div class="form-group">
+				<label for="fonts" class="col-lg-2 control-label">Include fonts</label>
+
+				<div class="col-lg-10">
+					<select id="fonts" name="fonts" class="form-control">
+						<option value="">None</option><?php
+						$list = FontProvider::getList();
+						foreach ( $list as $key => $label ) {
+							echo '<option value="' . $key . '"';
+							if ( $options['fonts'] == $key ) {
+								echo ' selected="selected"';
+							}
+							echo '>' . $label . '</option>' . "\n";
 						}
-						echo '>' . $label . '</option>';
-		   } ?>
-				</select>
-				<span class="help-inline"></span>
+						?></select>
+				</div>
 			</div>
-		</div>
-		<div class="form-group">
-			<label for="fonts" class="col-lg-2 control-label">Include fonts</label>
+			<div class="form-group">
+				<label class="col-lg-2 control-label">Options</label>
 
-			<div class="col-lg-10">
-				<select id="fonts" name="fonts" class="form-control">
-					<option value="">None</option><?php
-					$list = FontProvider::getList();
-					foreach ( $list as $key => $label ) {
-						echo '<option value="' . $key . '"';
-						if ( $options['fonts'] == $key ) {
-							echo ' selected="selected"';
-						}
-						echo '>' . $label . '</option>' . "\n";
-					}
-					?></select>
+				<div class="col-lg-10">
+					<label class="checkbox-inline">
+						<input type="checkbox" value="false" <?php
+						if ( !$options['images'] ) {
+							echo 'checked="checked"';
+						} ?> name="images"/>
+						Do not include images
+					</label>
+				</div>
 			</div>
-		</div>
-		<div class="form-group">
-			<label class="col-lg-2 control-label">Options</label>
-
-			<div class="col-lg-10">
-				<label class="checkbox-inline">
-					<input type="checkbox" value="false" <?php if ( !$options['images'] ) { echo 'checked="checked"';
-																																							   } ?> name="images"/>
-					Do not include images
-				</label>
+			<div class="form-group">
+				<div class="col-lg-offset-2 col-lg-10">
+					<input class="btn btn-primary" type="submit" value="Export"/>
+				</div>
 			</div>
-		</div>
-		<div class="form-group">
-			<div class="col-lg-offset-2 col-lg-10">
-				<input class="btn btn-primary" type="submit" value="Export"/>
-			</div>
-		</div>
-	</fieldset>
-</form>
+		</fieldset>
+	</form>
+	<aside class="col-md-3">
+		<h2>Recently popular</h2>
+		<ol>
+			<?php foreach ( CreationLog::singleton()->getRecentPopular() as $book ) { ?>
+				<li value="<?php echo $book['total'] ?>">
+					<a href="book.php?lang=<?php echo $book['lang'] ?>&page=<?php echo urlencode( $book['title'] ) ?>">
+						<?php echo str_replace( '_', ' ', $book['title'] ) ?>
+					</a>
+				</li>
+			<?php } ?>
+		</ol>
+		<p><a href="stat.php">More stats&hellip;</a></p>
+	</aside>
+</div>
 <?php include 'footer.html';

--- a/public/templates/stat.php
+++ b/public/templates/stat.php
@@ -1,4 +1,10 @@
 <?php include 'header.php'; ?>
+
+<ol class="breadcrumb">
+	<li><a href="book.php">Home</a></li>
+	<li class="active">Statistics</li>
+</ol>
+
 <table class="table table-striped">
 	<caption>Stats for <?php echo $month, '/', $year ?></caption>
 	<thead>

--- a/src/CreationLog.php
+++ b/src/CreationLog.php
@@ -59,6 +59,19 @@ class CreationLog {
 	}
 
 	/**
+	 * Get top 20 popular books in the last 3 months.
+	 */
+	public function getRecentPopular() {
+		$sql = 'SELECT `lang`, `title`, COUNT(*) AS `total`'
+			. ' FROM `' . $this->getTableName() . '`'
+			. ' WHERE `time` > DATE_SUB( CURRENT_DATE, INTERVAL 3 month)'
+			. ' GROUP BY `lang`, `title`'
+			. ' ORDER BY `total` DESC'
+			. ' LIMIT 20';
+		return $this->pdo->query( $sql )->fetchAll();
+	}
+
+	/**
 	 * Get total counts of exports by type and language.
 	 * @param string $month The month number.
 	 * @param string $year The year.


### PR DESCRIPTION
Add a list of books popular in the last 3 months to the left side
of the main page. Also add a breadcrub link back to the main page
from the stats page.

This patch indents a bunch of lines; it's easier to see the changes if you use Github's "ignore whitespace changes" option.