### PR TITLE
Clear all temp files

### DIFF
--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use DirectoryIterator;
 use Exception;
 
 /**
@@ -85,9 +86,12 @@ class FileCache {
 	/**
 	 * Cleans up file cache, deleting old files
 	 */
-	private function cleanup(): void {
-		foreach ( glob( $this->dir . '/*.*' ) as $fileName ) {
-			$this->checkFile( $fileName );
+	protected function cleanup(): void {
+		$di = new DirectoryIterator( $this->dir );
+		foreach ( $di as $file ) {
+			if ( $file->isFile() && !$file->isDot() ) {
+				$this->checkFile( $file->getPathname() );
+			}
 		}
 	}
 


### PR DESCRIPTION
The previous glob('*.*') was only selecting files with dots in
them for cleanup. This switches to DirectoryIterator on everything
in the temp directory.

https://phabricator.wikimedia.org/T246197

Bug:T246197