### PR TITLE
Calibre temp directories and cache cleanup

### DIFF
--- a/bin/cache-cleanup.php
+++ b/bin/cache-cleanup.php
@@ -1,0 +1,6 @@
+#!/usr/bin/php
+<?php
+
+require_once dirname( __DIR__ ) . '/bootstrap.php';
+
+\App\FileCache::singleton()->cleanup();

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -50,10 +50,21 @@ class FileCache {
 	}
 
 	/**
-	 * @return string Directory for temporary files
+	 * @return string Directory for temporary files, with no trailing slash.
 	 */
 	public function getDirectory(): string {
 		return $this->dir;
+	}
+
+	/**
+	 * Get a directory within the cache directory. It will be created if required.
+	 * @param string $sub The name of the subdirectory.
+	 * @return string The directory path, with no trailing slash.
+	 */
+	public function getSubdirectory( $sub ): string {
+		$subdir = $this->getDirectory() . '/' . rtrim( $sub, '/' );
+		$this->mkdir( $subdir );
+		return $subdir;
 	}
 
 	/**
@@ -74,19 +85,23 @@ class FileCache {
 		// Guard against realpth() returning false sometimes
 		$dir = realpath( $dir ) ?: $dir;
 
+		$this->mkdir( $dir );
+
+		return $dir;
+	}
+
+	private function mkdir( $dir ) {
 		if ( !is_dir( $dir ) ) {
 			if ( !mkdir( $dir, 0755 ) ) {
 				throw new Exception( "Couldn't create temporary directory $dir" );
 			}
 		}
-
-		return $dir;
 	}
 
 	/**
 	 * Cleans up file cache, deleting old files
 	 */
-	protected function cleanup(): void {
+	public function cleanup(): void {
 		$di = new DirectoryIterator( $this->dir );
 		foreach ( $di as $file ) {
 			if ( $file->isFile() && !$file->isDot() ) {

--- a/src/Generator/ConvertGenerator.php
+++ b/src/Generator/ConvertGenerator.php
@@ -3,6 +3,7 @@
 namespace App\Generator;
 
 use App\Book;
+use App\FileCache;
 use App\Util\Util;
 use InvalidArgumentException;
 use Symfony\Component\Process\Process;
@@ -139,6 +140,16 @@ class ConvertGenerator implements FormatGenerator {
 			explode( ' ', self::$CONFIG[$this->format]['parameters'] )
 		);
 		$process = new Process( $command );
+		$cache = FileCache::singleton();
+		// Calibre environment variables are documented at https://manual.calibre-ebook.com/customize.html
+		$process->setEnv( [
+			// Sets the directory where configuration files are stored/read.
+			'CALIBRE_CONFIG_DIRECTORY' => $cache->getSubdirectory( 'calibre-config' ),
+			// Sets the temporary directory used by Calibre.
+			'CALIBRE_TEMP_DIR' => $cache->getSubdirectory( 'calibre-temp' ),
+			// Sets the directory Calibre uses to cache persistent data between sessions
+			'CALIBRE_CACHE_DIRECTORY' => $cache->getSubdirectory( 'calibre-cache' ),
+		] );
 		$process->setTimeout( $wsexportConfig['exec-timeout'] ?? 120 );
 		$process->mustRun();
 	}


### PR DESCRIPTION
Move Calibre's temp directories into the tool's main temp
directory so that they can be cleaned up along with everything
else. Also add a CLI cache-cleanup command, which can be run by
cron and so lighten the load for web requests.

Bug: T246197