### PR TITLE
Sanitize output filenames of books

### DIFF
--- a/src/BookCreator.php
+++ b/src/BookCreator.php
@@ -13,6 +13,12 @@ class BookCreator {
 	private $bookProvider;
 	private $bookGenerator;
 
+	/** @var Book */
+	private $book;
+
+	/** @var string Full filesystem path to the created book. */
+	private $filePath;
+
 	public static function forApi( Api $api, $format, $options ) {
 		return new BookCreator(
 			new BookProvider( $api, $options ),
@@ -32,16 +38,23 @@ class BookCreator {
 		$this->bookGenerator = $bookGenerator;
 	}
 
-	public function create( $title, $outputPath = null ) {
+	/**
+	 * Create the book.
+	 * @param string $title
+	 * @param string|null $outputPath
+	 */
+	public function create( $title, $outputPath = null ): void {
 		date_default_timezone_set( 'UTC' );
 
-		$book = $this->bookProvider->get( $title );
-		$file = $this->bookGenerator->create( $book );
+		$this->book = $this->bookProvider->get( $title );
+		$this->filePath = $this->bookGenerator->create( $this->book );
 		if ( $outputPath ) {
-			return [ $book, $this->renameFile( $book->title, $file, $outputPath ) ];
-		} else {
-			return [ $book, $file ];
+			$this->renameFile( $outputPath );
 		}
+	}
+
+	public function getBook(): Book {
+		return $this->book;
 	}
 
 	public function getMimeType() {
@@ -52,14 +65,34 @@ class BookCreator {
 		return $this->bookGenerator->getExtension();
 	}
 
-	private function renameFile( $title, $file, $outputPath ) {
-		$output = $outputPath . '/' . $title . '.' . $this->getExtension();
-		if ( !is_dir( dirname( $output ) ) ) {
-			mkdir( dirname( $output ), 0755, true );
+	public function getFilePath(): string {
+		return $this->filePath;
+	}
+
+	/**
+	 * Get a sanitized filename for the created book.
+	 * @return string
+	 */
+	public function getFilename(): string {
+		return str_replace( [ '/', '\\' ], '_', trim( $this->book->title ) ) . '.' . $this->getExtension();
+	}
+
+	/**
+	 * Move the created book to a new directory.
+	 * @param string $dest The destination directory.
+	 * @throws Exception If the file could not be renamed.
+	 */
+	private function renameFile( string $dest ): void {
+		if ( !is_dir( $dest ) ) {
+			throw new Exception( 'Not a directory: ' . $dest );
 		}
-		if ( !rename( $file, $output ) ) {
-			throw new Exception( 'Unable to create output file: ' . $output );
+		$newFilePath = $dest . '/' . $this->getFilename();
+		if ( !is_dir( dirname( $newFilePath ) ) ) {
+			mkdir( dirname( $newFilePath ), 0755, true );
 		}
-		return $output;
+		if ( !rename( $this->getFilePath(), $newFilePath ) ) {
+			throw new Exception( 'Unable to create output file: ' . $newFilePath );
+		}
+		$this->filePath = $newFilePath;
 	}
 }

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -44,9 +44,9 @@ class ExportCommand extends Command {
 			'credits' => !$input->getOption( 'nocredits' ),
 		];
 		$creator = BookCreator::forLanguage( $input->getOption( 'lang' ), $input->getOption( 'format' ), $options );
-		list( $book, $file ) = $creator->create( $input->getOption( 'title' ), $input->getOption( 'path' ) );
+		$creator->create( $input->getOption( 'title' ), $input->getOption( 'path' ) );
 
-		$io->success( "The ebook has been created: $file" );
+		$io->success( "The ebook has been created: " . $creator->getFilePath() );
 
 		return Command::SUCCESS;
 	}

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -106,18 +106,18 @@ class ExportController extends AbstractController {
 		// Generate ebook.
 		$options = [ 'images' => $images, 'fonts' => $font ];
 		$creator = BookCreator::forApi( $api, $format, $options );
-		list( $book, $file ) = $creator->create( $title );
+		$creator->create( $title );
 
 		// Send file.
-		$response = new BinaryFileResponse( $file );
+		$response = new BinaryFileResponse( $creator->getFilePath() );
 		$response->headers->set( 'X-Robots-Tag', 'none' );
 		$response->headers->set( 'Content-Description', 'File Transfer' );
 		$response->headers->set( 'Content-Type', $creator->getMimeType() );
-		$response->setContentDisposition( ResponseHeaderBag::DISPOSITION_ATTACHMENT,  $title . '.' . $creator->getExtension() );
+		$response->setContentDisposition( ResponseHeaderBag::DISPOSITION_ATTACHMENT, $creator->getFilename() );
 		$response->deleteFileAfterSend();
 
 		// Log book generation.
-		$creationLog->add( $book, $format );
+		$creationLog->add( $creator->getBook(), $format );
 
 		return $response;
 	}

--- a/tests/BookCreator/BookCreatorIntegrationTest.php
+++ b/tests/BookCreator/BookCreatorIntegrationTest.php
@@ -59,10 +59,10 @@ class BookCreatorIntegrationTest extends TestCase {
 
 	private function createBook( $title, $language, $format ) {
 		$creator = BookCreator::forLanguage( $language, $format, [ 'credits' => false ] );
-		list( $book, $file ) = $creator->create( $title );
-		$this->assertFileExists( $file );
-		$this->assertNotNull( $book );
-		return $file;
+		$creator->create( $title );
+		$this->assertFileExists( $creator->getFilePath() );
+		$this->assertNotNull( $creator->getBook() );
+		return $creator->getFilePath();
 	}
 
 	private function epubCheck( $file ) {

--- a/tests/BookCreator/BookCreatorTest.php
+++ b/tests/BookCreator/BookCreatorTest.php
@@ -34,8 +34,8 @@ class BookCreatorTest extends TestCase {
 			->with( $this->equalTo( $book ) )
 			->will( $this->returnValue( 'path' ) );
 
-		list( $returnedBook, $file ) = $this->bookCreator->create( 'Test' );
-		$this->assertEquals( 'path', $file );
-		$this->assertSame( $book, $returnedBook );
+		$this->bookCreator->create( 'Test' );
+		$this->assertEquals( 'path', $this->bookCreator->getFilePath() );
+		$this->assertSame( $book, $this->bookCreator->getBook() );
 	}
 }


### PR DESCRIPTION
Exported filenames should not contain subpage slashes. They do
actually work, at least for some browsers, but Symfony doesn't
allow them and they also mean that books exported on the CLI
are put into subdirectories (which can be a bit odd — this also
makes this a breaking change, but we've already broken the
CLI format with the change to app:export so I don't think that
matters).

This change also removes the return values from BookCreator::create()
and replaces them with other getter methods on that class. This'll
make it easier when we come to turn that class into an injectable
service.

Bug: T263577