### PR TITLE
Restore MediaWiki.Commenting.PhpunitAnnotations sniff

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,6 @@
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.Missing.Protected" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.Missing.Public" />
-		<exclude name="MediaWiki.Commenting.PhpunitAnnotations" />
 		<exclude name="MediaWiki.NamingConventions.PrefixedGlobalFunctions.wfPrefix" />
 		<exclude name="MediaWiki.NamingConventions.ValidGlobalName" />
 		<exclude name="MediaWiki.Usage.SuperGlobalsUsage.SuperGlobals" />

--- a/tests/http/StatTest.php
+++ b/tests/http/StatTest.php
@@ -10,9 +10,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
  * @covers CreationLog
  */
 class StatTest extends WebTestCase {
-	/**
-	 * @runInSeparateProcess
-	 */
+
 	public function testGet() {
 		$client = static::createClient();
 


### PR DESCRIPTION
The HTTP tests are no longer required to run in separate processes
because they now use Symfony's KernelBrowser request system.