### PR TITLE
Remove $wsexportConfig['stat']

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,9 +17,6 @@ if ( !is_array( $wsexportConfig ) ) {
 	$kernelTmp->boot();
 	$container = $kernelTmp->getContainer();
 	$wsexportConfig = [
-		// 'debug' => $container->get( 'app.debug' ),
-		'stat' => $container->getParameter( 'app.enableStats' ),
-		// 'basePath' => $container->getParameter( 'app.basePath' ),
 		'tempPath' => $container->getParameter( 'app.tempPath' ) ?? dirname( __DIR__ ) . '/var/',
 		'exec-timeout' => $container->getParameter( 'app.execTimeout' ),
 	];

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,6 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-    app.enableStats: '%env(default::APP_ENABLE_STATS)%'
     app.tempPath: '%env(default::APP_TEMP_PATH)%'
     app.execTimeout: '%env(default::int:APP_TIMEOUT)%'
 
@@ -33,6 +32,10 @@ services:
     App\Util\Api:
         calls:
             - setLogger: [ '@logger' ]
+
+    App\CreationLog:
+        arguments:
+            $enableStats: '%env(bool:APP_ENABLE_STATS)%'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/CreationLog.php
+++ b/src/CreationLog.php
@@ -11,6 +11,9 @@ use Doctrine\DBAL\Connection;
  */
 class CreationLog {
 
+	/** @var bool */
+	private $enableStats;
+
 	/**
 	 * @var Connection
 	 */
@@ -19,8 +22,9 @@ class CreationLog {
 	/** @var string The name of the database table. */
 	protected $tableName = 'books_generated';
 
-	public function __construct( Connection $connection ) {
+	public function __construct( bool $enableStats, Connection $connection ) {
 		$this->db = $connection;
+		$this->enableStats = $enableStats;
 	}
 
 	/**
@@ -47,8 +51,7 @@ class CreationLog {
 	}
 
 	public function add( Book $book, $format ) {
-		global $wsexportConfig;
-		if ( !$wsexportConfig['stat'] ) {
+		if ( !$this->enableStats ) {
 			return;
 		}
 		$this->db->prepare(

--- a/tests/CreationLogTest.php
+++ b/tests/CreationLogTest.php
@@ -19,7 +19,7 @@ class CreationLogTest extends KernelTestCase {
 		parent::setUp();
 		self::bootKernel();
 		$this->db = self::$container->get( 'doctrine.dbal.default_connection' );
-		$this->log = new CreationLog( $this->db );
+		$this->log = self::$container->get( CreationLog::class );
 		$this->dropTable();
 	}
 

--- a/tests/Http/BookTest.php
+++ b/tests/Http/BookTest.php
@@ -31,9 +31,8 @@ class BookTest extends WebTestCase {
 	 */
 	public function testGetPage( $title, $language ) {
 		$client = static::createClient();
-		/** @var Connection $db */
-		$db = self::$container->get( 'doctrine.dbal.default_connection' );
-		( new CreationLog( $db ) )->createTable();
+		$creationLog = self::$container->get( CreationLog::class );
+		$creationLog->createTable();
 
 		$client->request( 'GET', '/book.php', [ 'page' => $title, 'lang' => $language ] );
 		$headers = $client->getResponse()->headers;

--- a/tests/Http/StatTest.php
+++ b/tests/Http/StatTest.php
@@ -14,9 +14,9 @@ class StatTest extends WebTestCase {
 	public function testGet() {
 		$client = static::createClient();
 
-		/** @var Connection $db */
-		$db = self::$container->get( 'doctrine.dbal.default_connection' );
-		( new CreationLog( $db ) )->createTable();
+		/** @var CreationLog $creationLog */
+		$creationLog = self::$container->get( CreationLog::class );
+		$creationLog->createTable();
 
 		$client->request( 'GET', '/stat.php' );
 		$this->assertStringContainsString( 'Stats for ', $client->getResponse()->getContent() );


### PR DESCRIPTION
This is a step towards fully removing the $wsexportConfig global
variable.

The CreationLog is already a service class, so to remove the 'stat'
key, we just have to inject that value (which comes from the
APP_ENABLE_STATS environment variable) into the class, and update
the tests.

https://phabricator.wikimedia.org/T265854