### PR TITLE
Make BookCreator injectable

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
         <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
         <env name="KERNEL_CLASS" value="\App\Kernel" />
         <env name="EPUBCHECK_JAR" value="/usr/bin/epubcheck" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="1" />
     </php>
 
     <testsuites>

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -19,9 +19,13 @@ class ExportCommand extends Command {
 	/** @var FontProvider */
 	private $fontProvider;
 
-	public function __construct( FontProvider $fontProvider ) {
+	/** @var BookCreator */
+	private $bookCreator;
+
+	public function __construct( FontProvider $fontProvider, BookCreator $bookCreator ) {
 		parent::__construct();
 		$this->fontProvider = $fontProvider;
+		$this->bookCreator = $bookCreator;
 	}
 
 	protected function configure() {
@@ -48,14 +52,16 @@ class ExportCommand extends Command {
 		}
 
 		$input->validate();
-		$options = [
-			'images' => true,
-			'credits' => !$input->getOption( 'nocredits' ),
-		];
-		$creator = BookCreator::forLanguage( $input->getOption( 'lang' ), $input->getOption( 'format' ), $options, $this->fontProvider );
-		$creator->create( $input->getOption( 'title' ), $input->getOption( 'path' ) );
 
-		$io->success( "The ebook has been created: " . $creator->getFilePath() );
+		$this->bookCreator->setTitle( $input->getOption( 'title' ) );
+		$this->bookCreator->setLang( $input->getOption( 'lang' ) );
+		$this->bookCreator->setOutputDir( $input->getOption( 'path' ) );
+		$this->bookCreator->setFormat( $input->getOption( 'format' ) );
+		$this->bookCreator->setIncludeCredits( !$input->getOption( 'nocredits' ) );
+
+		$this->bookCreator->create();
+
+		$io->success( "The ebook has been created: " . $this->bookCreator->getFilePath() );
 
 		return Command::SUCCESS;
 	}

--- a/tests/BookCreator/BookCreatorIntegrationTest.php
+++ b/tests/BookCreator/BookCreatorIntegrationTest.php
@@ -4,9 +4,12 @@ namespace App\Tests\BookCreator;
 
 use App\BookCreator;
 use App\FontProvider;
+use App\Util\Api;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestResult;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Process\Process;
 
 /**
@@ -67,8 +70,11 @@ class BookCreatorIntegrationTest extends TestCase {
 	 }
 
 	private function createBook( $title, $language, $format ) {
-		$creator = BookCreator::forLanguage( $language, $format, [ 'credits' => false ], $this->fontProvider );
-		$creator->create( $title );
+		$creator = new BookCreator( new Api( $language ), new NullLogger(), new FontProvider( new NullAdapter() ) );
+		$creator->setTitle( $title );
+		$creator->setFormat( $format );
+		$creator->setIncludeCredits( false );
+		$creator->create();
 		$this->assertFileExists( $creator->getFilePath() );
 		$this->assertNotNull( $creator->getBook() );
 		return $creator->getFilePath();


### PR DESCRIPTION
Refactor the BookCreator class so that it can be injected as a
service. This is the first step towards making it easier to use
common Symfony features such as caching in various places in the
codebase.

Bug: T265660