### PR TITLE
Add Beta, remove Wikibooks, and fix Wikilivres domain name

### DIFF
--- a/src/Util/Api.php
+++ b/src/Util/Api.php
@@ -60,11 +60,11 @@ class Api {
 			$this->domainName = 'wikisource.org';
 			$this->lang = '';
 		} elseif ( $this->lang == 'wl' || $this->lang == 'wikilivres' ) {
-			$this->domainName = 'wikilivres.ca';
+			$this->domainName = 'wikilivres.org';
 			$this->lang = '';
-		} elseif ( preg_match( '/^([a-z_]{2,})-?wikibooks$/', $this->lang, $m ) ) {
-			$this->domainName = $m[1] . '.wikibooks.org';
-			$this->lang = $m[1];
+		} elseif ( $this->lang === 'beta' ) {
+			$this->domainName = 'en.wikisource.beta.wmflabs.org';
+			$this->lang = '';
 		} else {
 			$this->domainName = $this->lang . '.wikisource.org';
 		}


### PR DESCRIPTION
Remove support for exporting from Wikibooks, and fix the domain
name of Wikilivres (although it's not currently working, that
might change), and add support for exporting from the Beta
Wikisource at en.wikisource.beta.wmflabs.org.

Bug: T266085
Bug: T259687