### PR TITLE
Update font-handling for better selection, weights, etc.

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -68,7 +68,7 @@ class ExportController extends AbstractController {
 		$font = $this->getFont( $request, $api->getLang(), $fontProvider );
 		$images = (bool)$request->get( 'images', true );
 		return $this->render( 'export.html.twig', [
-			'fonts' => $fontProvider->getPreferred( $font ),
+			'fonts' => $fontProvider->getAll(),
 			'font' => $font,
 			'formats' => GeneratorSelector::$formats,
 			'format' => $format,
@@ -156,7 +156,7 @@ class ExportController extends AbstractController {
 			}
 		}
 		return $this->render( 'export.html.twig', [
-			'fonts' => $fontProvider->getPreferred( $this->getFont( $request, $api->getLang(), $fontProvider ) ),
+			'fonts' => $fontProvider->getAll(),
 			'font' => $request->get( 'fonts' ),
 			'formats' => GeneratorSelector::$formats,
 			'format' => $request->get( 'format' ),

--- a/src/Generator/EpubGenerator.php
+++ b/src/Generator/EpubGenerator.php
@@ -76,8 +76,8 @@ class EpubGenerator implements FormatGenerator {
 
 		$font = $this->fontProvider->getOne( $book->options['fonts'] );
 		if ( $font !== null ) {
-			foreach ( $font['styles'] as $path ) {
-				$zip->addFile( $path, 'OPS/fonts/' . basename( $path ) );
+			foreach ( $font['styles'] as $styleInfo ) {
+				$zip->addFile( $styleInfo['file'], 'OPS/fonts/' . basename( $styleInfo['file'] ) );
 			}
 		}
 
@@ -154,7 +154,8 @@ class EpubGenerator implements FormatGenerator {
 		}
 		$font = $this->fontProvider->getOne( $book->options['fonts'] );
 		if ( $font !== null ) {
-			foreach ( $font['styles'] as $style => $path ) {
+			foreach ( $font['styles'] as $style => $styleInfo ) {
+				$path = $styleInfo['file'];
 				// Font mime types are listed at https://www.w3.org/publishing/epub32/epub-spec.html#cmt-grp-font
 				// They conveniently align with file extensions.
 				$mime = pathinfo( $path, PATHINFO_EXTENSION );

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -38,17 +38,17 @@
 			</div>
 		</div>
 		<div class="form-group">
-			<label for="fonts" class="col-lg-2 control-label">Include fonts</label>
-
+			<label for="fonts" class="col-lg-2 control-label">Font:</label>
 			<div class="col-lg-10">
 				<select id="fonts" name="fonts" class="form-control">
 					<option value="">None</option>
 					{% for key,label in fonts %}
 						<option value="{{ key|e('html_attr') }}" {% if key == font %}selected="selected"{% endif %}>
-							{{ label }}
+							{{ key }}
 						</option>
 					{% endfor %}
 				</select>
+				<p class="help-block">Choose from {{ fonts|length }} available fonts.</p>
 			</div>
 		</div>
 		<div class="form-group">

--- a/tests/FontProviderTest.php
+++ b/tests/FontProviderTest.php
@@ -48,19 +48,18 @@ class FontProviderTest extends TestCase {
 	 * @covers FontProvider::getCss()
 	 */
 	public function testGetCss() {
-		$this->assertSame( '@font-face {  font-family: "FreeSerif";  font-weight: bold;  font-style: italic;  src: url("fonts/FreeSerifBoldItalic.ttf");}
-@font-face {  font-family: "FreeSerif";  font-weight: bold;  font-style: normal;  src: url("fonts/FreeSerifBold.ttf");}
-@font-face {  font-family: "FreeSerif";  font-weight: normal;  font-style: normal;  src: url("fonts/FreeSerif.ttf");}
+		$this->assertSame( '@font-face {  font-family: "FreeSerif";  font-weight: normal;  font-style: normal;  src: url("fonts/FreeSerif.ttf");}
+@font-face {  font-family: "FreeSerif";  font-weight: 800;  font-style: normal;  src: url("fonts/FreeSerifBold.ttf");}
 @font-face {  font-family: "FreeSerif";  font-weight: normal;  font-style: italic;  src: url("fonts/FreeSerifItalic.ttf");}
+@font-face {  font-family: "FreeSerif";  font-weight: 800;  font-style: italic;  src: url("fonts/FreeSerifBoldItalic.ttf");}
 body { font-family: "FreeSerif" }
 ', $this->fontProvider->getCss( 'FreeSerif' ) );
-
-		$this->assertSame( '@font-face {  font-family: "Linux Libertine O";  font-weight: normal;  font-style: italic;  src: url("fonts/LinLibertine_RI.otf");}
-@font-face {  font-family: "Linux Libertine O";  font-weight: bold;  font-style: italic;  src: url("fonts/LinLibertine_RBI.otf");}
-@font-face {  font-family: "Linux Libertine O";  font-weight: 500;  font-style: italic;  src: url("fonts/LinLibertine_RZI.otf");}
-@font-face {  font-family: "Linux Libertine O";  font-weight: bold;  font-style: normal;  src: url("fonts/LinLibertine_RB.otf");}
-@font-face {  font-family: "Linux Libertine O";  font-weight: normal;  font-style: normal;  src: url("fonts/LinLibertine_R.otf");}
-@font-face {  font-family: "Linux Libertine O";  font-weight: 500;  font-style: normal;  src: url("fonts/LinLibertine_RZ.otf");}
+		$this->assertSame( '@font-face {  font-family: "Linux Libertine O";  font-weight: normal;  font-style: normal;  src: url("fonts/LinLibertine_R.otf");}
+@font-face {  font-family: "Linux Libertine O";  font-weight: bold;  font-style: normal;  src: url("fonts/LinLibertine_RZ.otf");}
+@font-face {  font-family: "Linux Libertine O";  font-weight: 800;  font-style: normal;  src: url("fonts/LinLibertine_RB.otf");}
+@font-face {  font-family: "Linux Libertine O";  font-weight: normal;  font-style: italic;  src: url("fonts/LinLibertine_RI.otf");}
+@font-face {  font-family: "Linux Libertine O";  font-weight: bold;  font-style: italic;  src: url("fonts/LinLibertine_RZI.otf");}
+@font-face {  font-family: "Linux Libertine O";  font-weight: 800;  font-style: italic;  src: url("fonts/LinLibertine_RBI.otf");}
 body { font-family: "Linux Libertine O" }
 ', $this->fontProvider->getCss( 'linuxlibertine' ) );
 


### PR DESCRIPTION
The existing font family name handling wasn't taking into account
the fact that fc-list reports these with alternate names appearing
after a comma. This removes this trailing info, and also adds more
thorough weight and slant handling.

The dropdown list is also updated to include all available fonts,
because it sounds like at some point we'll update this to be more
responsive and useful but for now this makes it much easier to
test and see what is available.

Bug: T261479