### PR TITLE
Always HTML-escape error messages

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -39,7 +39,7 @@
 		{% for type, msgs in app.flashes|merge(messages ?? {}) %}
 			<div class="alerts">
 				{% for msg in msgs %}
-					<div class="alert alert-{{ type }}">{{ msg|raw }}</div>
+					<div class="alert alert-{{ type }}">{{ msg }}</div>
 				{% endfor %}
 			</div>
 		{% endfor %}


### PR DESCRIPTION
There used to be HTML in some error messages, but none now, so
it's no longer necessary to treat them as raw HTML in Twig.