### PR TITLE
Validate URL 'format' parameter

### DIFF
--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -52,6 +52,14 @@ class ExportCommand extends Command {
 			return Command::FAILURE;
 		}
 
+		$format = $input->getOption( 'format' );
+		if ( !array_key_exists( $format, GeneratorSelector::$formats ) ) {
+			$msgFormat = '"%s" is not a valid format. Valid formats are: %s';
+			$msg = sprintf( $msgFormat, $format, '"' . implode( '", "', array_keys( GeneratorSelector::$formats ) ) . '"' );
+			$io->warning( $msg );
+			return Command::FAILURE;
+		}
+
 		$input->validate();
 		$options = [
 			'images' => true,

--- a/src/Exception/WSExportInvalidArgumentException.php
+++ b/src/Exception/WSExportInvalidArgumentException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace App\Exception;
-
-use InvalidArgumentException;
-
-class WSExportInvalidArgumentException extends InvalidArgumentException {
-}

--- a/src/GeneratorSelector.php
+++ b/src/GeneratorSelector.php
@@ -2,11 +2,11 @@
 
 namespace App;
 
-use App\Exception\WSExportInvalidArgumentException;
 use App\Generator\AtomGenerator;
 use App\Generator\ConvertGenerator;
 use App\Generator\EpubGenerator;
 use App\Util\Api;
+use Exception;
 
 class GeneratorSelector {
 
@@ -46,7 +46,7 @@ class GeneratorSelector {
 		} elseif ( $format === 'atom' ) {
 			return new AtomGenerator();
 		} else {
-			throw new WSExportInvalidArgumentException( "The file format '$format' is unknown." );
+			throw new Exception( "The file format '$format' is unknown." );
 		}
 	}
 }

--- a/tests/Book/GeneratorSelectorTest.php
+++ b/tests/Book/GeneratorSelectorTest.php
@@ -2,12 +2,12 @@
 
 namespace App\Tests\Book;
 
-use App\Exception\WSExportInvalidArgumentException;
 use App\FontProvider;
 use App\Generator\ConvertGenerator;
 use App\Generator\EpubGenerator;
 use App\GeneratorSelector;
 use App\Util\Api;
+use Exception;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -34,7 +34,7 @@ class GeneratorSelectorTest extends KernelTestCase {
 	}
 
 	public function testGetUnknownGeneratorRaisesException() {
-		$this->expectException( WSExportInvalidArgumentException::class );
+		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( "The file format 'unknown' is unknown." );
 		$this->generatorSelector->getGenerator( "unknown" );
 	}

--- a/tests/Http/BookTest.php
+++ b/tests/Http/BookTest.php
@@ -3,7 +3,6 @@
 namespace App\Tests\Http;
 
 use App\CreationLog;
-use App\Exception\WSExportInvalidArgumentException;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -51,10 +50,9 @@ class BookTest extends WebTestCase {
 
 	public function testGetInvalidFormatDisplaysError() {
 		$client = static::createClient();
-		$this->expectException( WSExportInvalidArgumentException::class );
 		$client->request( 'GET', '/book.php', [ 'page' => 'xxx', 'format' => 'xxx' ] );
-		$this->assertStringContainsString( "The file format 'xxx' is unknown.", $client->getResponse()->getContent() );
-		$this->assertSame( 500, $client->getResponse()->getStatusCode() );
+		$this->assertStringContainsString( '&quot;xxx&quot; is not a valid format.', $client->getResponse()->getContent() );
+		$this->assertSame( 404, $client->getResponse()->getStatusCode() );
 	}
 
 	/**


### PR DESCRIPTION
Avoid blank format param in ExportController and use a 404
exception instead of 500 for invalid format names.

Bug: T269343