### PR TITLE
Remove data-mw attributes from books

### DIFF
--- a/src/PageParser.php
+++ b/src/PageParser.php
@@ -224,6 +224,7 @@ class PageParser {
 		$this->deprecatedAttributes( 'cellspacing', 'border-spacing' );
 		$this->deprecatedAttributes( 'data-file-height', null );
 		$this->deprecatedAttributes( 'data-file-width', null );
+		$this->deprecatedAttributes( 'data-mw', null );
 		$this->deprecatedAttributes( 'lang', 'xml:lang', false );
 
 		$this->cleanIds();


### PR DESCRIPTION
Remove the 'data-mw' attribute that is included in different DOM
elements.