### PR TITLE
Disable xdebug by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Wikisource Export should be up at http://localhost:8888/
 
 
 ### Setup Xdebug
+Xdebug is disabled by default. If you need to enable it you can do so via an env variable by creating a `./docker/docker-compose.override.yml` file with the following content
+```
+version: '3.7'
+services:
+  wsexport:
+    environment:
+     - XDEBUG_MODE=debug
+```
 
 #### Visual Studio Code
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,10 +5,6 @@ ARG GROUP_ID
 
 WORKDIR /var/www/html
 
-COPY ./apache/000-default.conf /etc/apache2/sites-available/
-COPY ./apache/ports.conf /etc/apache2/
-COPY ./php.ini /usr/local/etc/php/php.ini
-
 EXPOSE 8080
 
 # work around https://github.com/docker-library/openjdk/blob/0584b2804ed12dca7c5e264b5fc55fc07a3ac148/8-jre/slim/Dockerfile#L51-L54

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,10 +10,14 @@ services:
       - "8888:8080"
     volumes:
       - ../:/var/www/html:cached
+      - ./apache/000-default.conf:/etc/apache2/sites-available/000-default.conf:cached
+      - ./apache/ports.conf:/etc/apache2/ports.conf:cached
+      - ./php.ini:/usr/local/etc/php/php.ini:cached
     links:
       - database:database
     environment:
-      APACHE_RUN_USER: daemon
+      - APACHE_RUN_USER=daemon
+      - XDEBUG_MODE=off
     depends_on:
       - database
   database:

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,9 +1,5 @@
 [xdebug]
-xdebug.profiler_enable=1
-xdebug.remote_enable=1
-xdebug.remote_handler=dbgp
-xdebug.remote_mode=req
-xdebug.remote_host=host.docker.internal
-xdebug.remote_port=9000
-xdebug.remote_autostart=1
-xdebug.remote_connect_back=1
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9000
+xdebug.start_with_request=yes
+xdebug.discover_client_host=1


### PR DESCRIPTION
Xdebug v3 triggers an exception on symfony di when compiling. This only
fails when calling app:install and cache:clear (afaik)

After the initial setup, xdebug can be enabled if needed and works as
expected unless you need to recompile the container.

Also in this patch
* Move configs to be mounted instead of copied at build time
* Upgrade xdebug config to work with v3