### PR TITLE
Cache namespaces for 1 month

### DIFF
--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -2,14 +2,7 @@
 
 namespace App;
 
-/**
- * @author Thomas Pellissier Tanon
- * @copyright 2011 Thomas Pellissier Tanon
- * @license GPL-2.0-or-later
- */
-
 use App\Util\Api;
-use App\Util\Util;
 use DOMDocument;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -113,7 +106,7 @@ class BookProvider {
 			$book->categories = $this->getCategories( $metadataSrc );
 		}
 		$pageTitles = $parser->getPagesList();
-		$namespaces = $this->getNamespaces();
+		$namespaces = $this->api->getNamespaces();
 		if ( !$isMetadata ) {
 			if ( !$parser->metadataIsSet( 'ws-noinclude' ) ) {
 				$book->content = $parser->getContent( true );
@@ -387,19 +380,6 @@ class BookProvider {
 	}
 
 	/**
-	 * return the list of the namespaces for the current wiki.
-	 * @return string[]
-	 */
-	public function getNamespaces() {
-		$namespaces = unserialize( Util::getTempFile( $this->api, $this->api->getLang(), 'namespaces.sphp' ) );
-		if ( is_array( $namespaces ) ) {
-			return $namespaces;
-		} else {
-			return [];
-		}
-	}
-
-	/**
 	 * Splits an array of strings into multiple arrays small enough to fit into a Toolforge URL
 	 *
 	 * @param string[] $array
@@ -421,7 +401,7 @@ class BookProvider {
 	}
 
 	private function removeNamespacesFromTitle( $title ) {
-		foreach ( $this->getNamespaces() as $namespace ) {
+		foreach ( $this->api->getNamespaces() as $namespace ) {
 			if ( strpos( $title, $namespace . ':' ) === 0 ) {
 				return substr( $title, strlen( $namespace ) + 1 );
 			}

--- a/src/Refresh.php
+++ b/src/Refresh.php
@@ -27,7 +27,6 @@ class Refresh {
 		$this->getI18n();
 		$this->getEpubCssWikisource();
 		$this->getAboutXhtmlWikisource();
-		$this->getNamespacesList();
 	}
 
 	protected function getI18n() {
@@ -77,25 +76,6 @@ class Refresh {
 			$aboutHtml = str_replace( 'href="./', 'href="https://' . $this->api->getDomainName() . '/wiki/', $aboutHtml );
 			$this->setTempFileContent( 'about.xhtml', $aboutHtml );
 		}
-	}
-
-	protected function getNamespacesList() {
-		$namespaces = [];
-		$response = $this->api->query( [ 'meta' => 'siteinfo', 'siprop' => 'namespaces|namespacealiases' ] );
-		foreach ( $response['query']['namespaces'] as $namespace ) {
-			if ( array_key_exists( '*', $namespace ) && $namespace['*'] ) {
-				$namespaces[] = $namespace['*'];
-			}
-			if ( array_key_exists( 'canonical', $namespace ) && $namespace['canonical'] ) {
-				$namespaces[] = $namespace['canonical'];
-			}
-		}
-		foreach ( $response['query']['namespacealiases'] as $namespaceAlias ) {
-			if ( array_key_exists( '*', $namespaceAlias ) ) {
-				$namespaces[] = $namespaceAlias['*'];
-			}
-		}
-		$this->setTempFileContent( 'namespaces.sphp', serialize( $namespaces ) );
 	}
 
 	protected function setTempFileContent( $name, $content ) {

--- a/tests/Book/BookProviderTest.php
+++ b/tests/Book/BookProviderTest.php
@@ -27,16 +27,18 @@ class BookProviderTest extends TestCase {
 			'User A' => [ 'count' => 20, 'flags' => [ 'autoreview', 'editor', 'reviewer', 'sysop' ] ]
 		];
 		$responses = [
+			// Namespaces.
+			new Response( 200, [], json_encode( [ 'query' => [ 'namespaces' => [ [ '*' => 'test' ] ], 'namespacealiases' => [] ] ] ) ),
+			// Credits.
 			new Response( 200, [ 'Content-Type' => 'application/json' ], json_encode( $creditResponse ) ),
-			// The rest of these responses are required for mocking the Refresh process (namespaces, 'about' page, etc.)
+			// The rest of these responses are required for mocking the Refresh process ('about' page, etc.).
 			new Response( 200, [], '' ),
 			new Response( 404, [], '' ), // mock returning 404 in first api call in Refresh::getAboutXhtmlWikisource
 			new Response( 200, [], '' ), // mock getting content from '$oldWikisourceApi' in Refresh::getAboutXhtmlWikisource
-			new Response( 200, [], json_encode( [ 'query' => [ 'namespaces' => [ [ '*' => 'test' ] ], 'namespacealiases' => [] ] ] ) ),
 		];
 		$this->mockHandler = new MockHandler( $responses );
 		$client = new Client( [ 'handler' => HandlerStack::create( $this->mockHandler ) ] );
-		$api = new Api( new NullLogger(), new NullAdapter(), $client );
+		$api = new Api( new NullLogger(), new NullAdapter(), new NullAdapter(), $client );
 		$api->setLang( 'en' );
 		$this->bookProvider = new BookProvider( $api, [ 'categories' => false, 'credits' => true ] );
 	}

--- a/tests/Book/RefreshTest.php
+++ b/tests/Book/RefreshTest.php
@@ -49,15 +49,8 @@ class RefreshTest extends KernelTestCase {
 		$this->assertStringContainsString( 'Test-About-Content', $about );
 	}
 
-	public function testRefreshUpdatesNamespacesList() {
-		$this->refresh( 'en' );
-
-		$namespaces = unserialize( Util::getTempFile( $this->api, 'en', 'namespaces.sphp' ) );
-		$this->assertEquals( [ '0' => 'test' ], $namespaces );
-	}
-
 	private function refresh( $lang ) {
-		$api = new Api( new NullLogger(), new NullAdapter(), $this->mockClient( $this->defaultResponses() ) );
+		$api = new Api( new NullLogger(), new NullAdapter(), new NullAdapter(), $this->mockClient( $this->defaultResponses() ) );
 		$api->setLang( $lang );
 		$refresh = new Refresh( $api );
 		$refresh->refresh();
@@ -72,7 +65,6 @@ class RefreshTest extends KernelTestCase {
 			$this->mockI18NResponse( 'title_page = "Test-Title"' ),
 			$this->mockCssWikisourceResponse( '#TEST-CSS' ),
 			$this->mockAboutWikisourceResponse( 'Test-About-Title', 'Test-About-Content' ),
-			$this->mockNamespacesListResponse( [ '*' => 'test' ] )
 		];
 	}
 
@@ -96,11 +88,5 @@ class RefreshTest extends KernelTestCase {
 				<base href="//en.wikisource.org/wiki/"/><link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=mediawiki.skinning.content.parsoid%7Cmediawiki.skinning.interface%7Csite.styles%7Cmediawiki.page.gallery.styles%7Cext.cite.style%7Cext.cite.styles&amp;only=styles&amp;skin=vector"/><meta http-equiv="content-language" content="en"/><meta http-equiv="vary" content="Accept"/></head>
 				<body>' . $content . '</body></html>'
 			);
-	}
-
-	private function mockNamespacesListResponse( $namespaces ) {
-		return new Response( 200, [ 'Content' => 'application/json' ],
-			json_encode( [ 'query' => [ 'namespaces' => [ $namespaces ], 'namespacealiases' => [] ] ] )
-		 );
 	}
 }

--- a/tests/Util/ApiTest.php
+++ b/tests/Util/ApiTest.php
@@ -42,7 +42,7 @@ class ApiTest extends TestCase {
 	}
 
 	private function apiWithResponse( $status, $header, $body ) {
-		$api = new Api( new NullLogger(), new NullAdapter(), $this->mockClient( [ new Response( $status, $header, $body ) ] ) );
+		$api = new Api( new NullLogger(), new NullAdapter(), new NullAdapter(), $this->mockClient( [ new Response( $status, $header, $body ) ] ) );
 		$api->setLang( 'en' );
 		return $api;
 	}


### PR DESCRIPTION
Remove the manual caching of namespaces, and instead use standard
Symfony caching in the Api class, along with a runtime variable
to avoid multiple calls to the filesystem.

Bug: T265660