### PR TITLE
fix: support font embedding in Apple iBooks

### DIFF
--- a/src/Generator/EpubGenerator.php
+++ b/src/Generator/EpubGenerator.php
@@ -69,6 +69,7 @@ class EpubGenerator implements FormatGenerator {
 		$fileName = Util::buildTemporaryFileName( $book->title, 'epub' );
 		$zip = $this->createZipFile( $fileName );
 		$zip->addFromString( 'META-INF/container.xml', $this->getXmlContainer() );
+		$zip->addFromString( 'META-INF/com.apple.ibooks.display-options.xml', $this->getAppleIBooksDisplayOptionsXml() );
 		$zip->addFromString( 'OPS/content.opf', $this->getOpfContent( $book, $wsUrl ) );
 		$zip->addFromString( 'OPS/toc.ncx', $this->getNcxToc( $book, $wsUrl ) );
 		$zip->addFromString( 'OPS/nav.xhtml', $this->getXhtmlNav( $book ) );
@@ -214,6 +215,17 @@ class EpubGenerator implements FormatGenerator {
 					<rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml" />
 				</rootfiles>
 			</container>';
+
+		return $content;
+	}
+
+	private function getAppleIBooksDisplayOptionsXml() {
+		$content = '<?xml version="1.0" encoding="UTF-8" ?>
+			<display_options>
+				<platform name="*">
+					<option name="specified-fonts">true</option>
+				</platform>
+			</display_options>';
 
 		return $content;
 	}


### PR DESCRIPTION
Apple Books requires this file for embedded fonts.

See https://help.apple.com/itc/booksassetguide/en.lproj/static.html#itc2cf4d26eb

also https://www.mobileread.com/forums/showthread.php?t=192389

Works on my local macOS and iOS:

![image](https://user-images.githubusercontent.com/3607926/102645353-57128800-4130-11eb-8528-dfdf52f0f53e.png)

Use case: I uses embed font to support characters in the Unicode SIP Plane.