### PR TITLE
Record book generation duration

### DIFF
--- a/migrations/Version20201222094802.php
+++ b/migrations/Version20201222094802.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201222094802 extends AbstractMigration {
+
+	public function getDescription() : string {
+		return 'Add duration column.';
+	}
+
+	public function up( Schema $schema ) : void {
+		$this->addSql( 'ALTER TABLE books_generated ADD duration INT DEFAULT NULL' );
+	}
+
+	public function down( Schema $schema ) : void {
+		$this->addSql( 'ALTER TABLE books_generated DROP duration' );
+	}
+}

--- a/src/Entity/GeneratedBook.php
+++ b/src/Entity/GeneratedBook.php
@@ -8,6 +8,7 @@ use DateTimeZone;
 // mediawiki-codesniffer apparently can't search annotations for unused classes.
 // phpcs:ignore MediaWiki.Classes.UnusedUseStatement.UnusedUse
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Stopwatch\StopwatchEvent;
 
 /**
  * The GeneratedBook is the log of exports.
@@ -32,7 +33,7 @@ class GeneratedBook {
 
 	/**
 	 * @ORM\Column(type="datetime")
-	 * @var DateTime Time of the export.
+	 * @var DateTime Date and time of the export.
 	 */
 	private $time;
 
@@ -55,15 +56,26 @@ class GeneratedBook {
 	private $format;
 
 	/**
+	 * @ORM\Column(type="integer", nullable=true)
+	 * @var int|null The book generation duration in seconds.
+	 */
+	private $duration;
+
+	/**
 	 * GeneratedBook constructor.
 	 * @param Book $book
 	 * @param string $format
+	 * @param StopwatchEvent|null $duration
 	 */
-	public function __construct( Book $book, string $format ) {
+	public function __construct( Book $book, string $format, ?StopwatchEvent $duration = null ) {
 		$this->setTime( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) );
 		$this->setLang( $book->lang );
 		$this->setTitle( $book->title );
 		$this->setFormat( $format );
+		if ( $duration ) {
+			// Round up to the nearest second.
+			$this->setDuration( ceil( $duration->getDuration() / 1000 ) );
+		}
 	}
 
 	/**
@@ -127,5 +139,20 @@ class GeneratedBook {
 	 */
 	public function setFormat( string $format ): void {
 		$this->format = $format;
+	}
+
+	/**
+	 * Get the generation duration in seconds.
+	 * @return int|null
+	 */
+	public function getDuration(): ?int {
+		return $this->duration;
+	}
+
+	/**
+	 * @param int|null $duration The duration in seconds.
+	 */
+	public function setDuration( ?int $duration ): void {
+		$this->duration = $duration;
 	}
 }

--- a/tests/Http/BookTest.php
+++ b/tests/Http/BookTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Http;
 
+use App\Entity\GeneratedBook;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -35,6 +36,15 @@ class BookTest extends WebTestCase {
 		$this->assertSame( 'application/epub+zip', $headers->get( 'Content-Type' ) );
 		$this->assertSame( 'attachment; filename=The_Kiss_and_its_History.epub', $headers->get( 'Content-Disposition' ) );
 		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+
+		// Test that it took at least a second to generate.
+		/** @var GeneratedBook $genBook */
+		$genBook = self::$container
+			->get( 'doctrine' )
+			->getManager()
+			->getRepository( GeneratedBook::class )
+			->findOneBy( [ 'lang' => $language, 'title' => $title ], [ 'time' => 'DESC' ] );
+		$this->assertGreaterThanOrEqual( 1, $genBook->getDuration() );
 	}
 
 	public function testGetNonExistingTitleDisplaysError() {


### PR DESCRIPTION
Add a new 'duration' column to the DB table, to record the number
of seconds each book generation took.

Bug: T267079