### PR TITLE
fix: do not provide free serif to zh/jp/kr

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -152,7 +152,7 @@ class ExportController extends AbstractController {
 	private function getFont( Request $request, $lang, FontProvider $fontProvider ): ?string {
 		// Default font for non-latin languages.
 		$font = $fontProvider->resolveName( $request->get( 'fonts' ) );
-		if ( !$font && !in_array( $lang, [ 'fr', 'en', 'de', 'it', 'es', 'pt', 'vec', 'pl', 'nl', 'fa', 'he', 'ar' ] ) ) {
+		if ( !$font && !in_array( $lang, [ 'fr', 'en', 'de', 'it', 'es', 'pt', 'vec', 'pl', 'nl', 'fa', 'he', 'ar', 'zh', 'jp', 'kr' ] ) ) {
 			$font = 'FreeSerif';
 		}
 		if ( !$fontProvider->getOne( $font ) ) {


### PR DESCRIPTION
> GNU FreeFont implements [...] aside from the very large CJK Asian character set.

https://en.wikipedia.org/wiki/GNU_FreeFont

Context: https://github.com/wsexport/tool/pull/296#issuecomment-748816532