### PR TITLE
Add special handling for table align attributes

### DIFF
--- a/src/PageParser.php
+++ b/src/PageParser.php
@@ -253,7 +253,7 @@ class PageParser {
 		$this->deprecatedNodes( 'u', 'span', 'text-decoration:underline;' );
 		$this->deprecatedNodes( 'font', 'span', '' );
 
-		$this->deprecatedAttributes( 'align', 'text-align' );
+		$this->convertAlignAttributes();
 		$this->deprecatedAttributes( 'background', 'background-color' );
 		$this->deprecatedAttributes( 'bgcolor', 'background-color' );
 		$this->deprecatedAttributes( 'border', 'border-width' );
@@ -356,6 +356,27 @@ class PageParser {
 				}
 			}
 			$node->removeAttribute( $name );
+		}
+	}
+
+	private function convertAlignAttributes() {
+		$nodes = $this->xPath->query( '//*[@align]' );
+		/** @var DOMElement $node */
+		foreach ( $nodes as $node ) {
+			$alignment = $node->getAttribute( 'align' );
+			// Tables have their own (deprecated) align attribute.
+			// https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement/align
+			if ( $node->tagName === 'table' && $alignment === 'left' ) {
+				$css = "margin-right: auto";
+			} elseif ( $node->tagName === 'table' && $alignment === 'right' ) {
+				$css = "margin-left: auto";
+			} elseif ( $node->tagName === 'table' && $alignment === 'center' ) {
+				$css = "margin: auto";
+			} else {
+				$css = 'text-align: ' . $alignment;
+			}
+			$node->setAttribute( 'style', trim( $css . '; ' . $node->getAttribute( 'style' ) ) );
+			$node->removeAttribute( 'align' );
 		}
 	}
 

--- a/tests/Book/PageParserTest.php
+++ b/tests/Book/PageParserTest.php
@@ -105,4 +105,35 @@ class PageParserTest extends TestCase {
 		$this->assertTrue( $doc->loadHTMLFile( $filename ), 'parsing of "' . $filename . '"" failed' );
 		return new PageParser( $doc );
 	}
+
+	/**
+	 * @dataProvider provideAlignAttr()
+	 */
+	public function testAlignAttr( string $in, string $out ) {
+		$doc1 = new DOMDocument();
+		$doc1->loadHTML( $in );
+		$pageParser1 = new PageParser( $doc1 );
+		$this->assertStringContainsString( $out, $pageParser1->getContent( false )->saveHTML() );
+	}
+
+	public function provideAlignAttr() {
+		return [
+			[
+				'<table align="center"></table>',
+				'<table style="margin: auto;"></table>',
+			],
+			[
+				'<table align="right"></table>',
+				'<table style="margin-left: auto;"></table>',
+			],
+			[
+				'<div align="center" style="color: green"></div>',
+				'<div style="text-align: center; color: green"></div>',
+			],
+			[
+				'<div align="right"></div>',
+				'<div style="text-align: right;"></div>',
+			],
+		];
+	}
 }


### PR DESCRIPTION
align attributes were being converted to text-align:center
but should be modifying margins for tables.

Bug: T270807