### PR TITLE
Cache 'about' page with app cache

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use GuzzleHttp\Exception\RequestException;
 use Locale;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -47,9 +48,9 @@ class ExportController extends AbstractController {
 	/**
 	 * @Route("/refresh", name="refresh")
 	 */
-	public function refresh( Request $request, Api $api ) {
+	public function refresh( Request $request, Api $api, CacheItemPoolInterface $cacheItemPool ) {
 		$api->setLang( $this->getLang( $request ) );
-		$refresh = new Refresh( $api );
+		$refresh = new Refresh( $api, $cacheItemPool );
 		$refresh->refresh();
 		$this->addFlash( 'success', 'The cache is updated for ' . $api->getLang() . ' language.' );
 		return $this->redirectToRoute( 'home' );

--- a/src/Generator/EpubGenerator.php
+++ b/src/Generator/EpubGenerator.php
@@ -409,7 +409,8 @@ class EpubGenerator implements FormatGenerator {
 		}
 		$list .= '</ul>';
 		$listBot .= '</ul>';
-		$about = Util::getTempFile( $this->api, $book->lang, 'about.xhtml' );
+
+		$about = $this->api->getAboutPage();
 		if ( $about == '' ) {
 			$about = Util::getXhtmlFromContent( $book->lang, $list, $this->i18n['about'] );
 		} else {

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -89,7 +89,7 @@ class Util {
 		$path = $cache->getDirectory() . '/' . $lang . '/' . $name;
 		if ( !file_exists( $path ) ) {
 			$api->setLang( $lang );
-			$refresh = new Refresh( $api );
+			$refresh = new Refresh( $api, $api->getCache() );
 			$refresh->refresh();
 		}
 		return file_get_contents( $path );

--- a/tests/Book/RefreshTest.php
+++ b/tests/Book/RefreshTest.php
@@ -42,17 +42,10 @@ class RefreshTest extends KernelTestCase {
 		$this->assertStringEndsWith( '#TEST-CSS', $css );
 	}
 
-	public function testRefreshUpdatesAboutXhtmlWikisource() {
-		$this->refresh( 'en' );
-
-		$about = Util::getTempFile( $this->api, 'en', 'about.xhtml' );
-		$this->assertStringContainsString( 'Test-About-Content', $about );
-	}
-
 	private function refresh( $lang ) {
 		$api = new Api( new NullLogger(), new NullAdapter(), new NullAdapter(), $this->mockClient( $this->defaultResponses() ) );
 		$api->setLang( $lang );
-		$refresh = new Refresh( $api );
+		$refresh = new Refresh( $api, new NullAdapter() );
 		$refresh->refresh();
 	}
 
@@ -64,7 +57,6 @@ class RefreshTest extends KernelTestCase {
 		return [
 			$this->mockI18NResponse( 'title_page = "Test-Title"' ),
 			$this->mockCssWikisourceResponse( '#TEST-CSS' ),
-			$this->mockAboutWikisourceResponse( 'Test-About-Title', 'Test-About-Content' ),
 		];
 	}
 

--- a/tests/Util/ApiTest.php
+++ b/tests/Util/ApiTest.php
@@ -50,4 +50,9 @@ class ApiTest extends TestCase {
 	private function mockClient( $responses ) {
 		return new Client( [ 'handler' => HandlerStack::create( new MockHandler( $responses ) ) ] );
 	}
+
+	public function testGetAboutPage(): void {
+		$api = $this->apiWithResponse( 200, [], '<body><a href="./Foo">Foo</a></body>' );
+		$this->assertStringContainsString( '<body><a href="https://en.wikisource.org/wiki/Foo">Foo</a></body>', $api->getAboutPage() );
+	}
 }


### PR DESCRIPTION
Switch from manually storing the about pages in files, to using
Symfony cache with a TTL of 1 month.

Bug: T271876