### PR TITLE
Escape href value when searching for subpages

### DIFF
--- a/src/PageParser.php
+++ b/src/PageParser.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Util\Util;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
@@ -113,7 +114,7 @@ class PageParser {
 	public function getFullChaptersList( $title, $pageList, $namespaces ) {
 		$chapters = $this->getChaptersList( $pageList, $namespaces );
 		if ( empty( $chapters ) ) {
-			$list = $this->xPath->query( '//a[contains(@href,"' . $title . '") and 
+			$list = $this->xPath->query( '//a[contains(@href,"' . Util::wfUrlencode( $title ) . '") and
 				not(
 					contains(@class,"new") or
 					contains(@class,"extiw") or
@@ -127,11 +128,11 @@ class PageParser {
 				)]' );
 			/** @var DOMElement $link */
 			foreach ( $list as $link ) {
-				$title = str_replace( ' ', '_', $link->getAttribute( 'title' ) );
-				$parts = explode( ':', $title );
-				if ( $title != '' && !in_array( $title, $pageList ) && !in_array( $parts[0], $namespaces ) ) {
+				$linkTitle = str_replace( ' ', '_', $link->getAttribute( 'title' ) );
+				$parts = explode( ':', $linkTitle );
+				if ( $linkTitle != '' && !in_array( $linkTitle, $pageList ) && !in_array( $parts[0], $namespaces ) ) {
 					$chapter = new Page();
-					$chapter->title = $title;
+					$chapter->title = $linkTitle;
 					$chapter->name = $link->nodeValue;
 					$chapters[] = $chapter;
 					$pageList[] = $chapter->title;

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -214,4 +214,21 @@ class Util {
 
 		return $text ? "$message: $text" : $message;
 	}
+
+	/**
+	 * MediaWiki's version of urlencode, which doesn't encode these: ;:@&=$-_.+!*'(),
+	 *
+	 * Copied from MediaWiki's includes/GlobalFunctions.php file:
+	 * https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/c8b1375fb9883f076c44fdd41508236c60fe8465/includes/GlobalFunctions.php#312
+	 *
+	 * @param string $str
+	 * @return string
+	 */
+	public static function wfUrlencode( string $str ): string {
+		return str_ireplace(
+			[ '%3B', '%40', '%24', '%21', '%2A', '%28', '%29', '%2C', '%2F', '%7E', '%3A' ],
+			[ ';', '@', '$', '!', '*', '(', ')', ',', '/', '~', ':' ],
+			urlencode( $str )
+		);
+	}
 }

--- a/tests/Book/PageParserTest.php
+++ b/tests/Book/PageParserTest.php
@@ -136,4 +136,14 @@ class PageParserTest extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * If a work doesn't include ws-summary, we want to get all of it's subpage links as the ToC.
+	 */
+	public function testSubpagesEncodedHrefs() {
+		$doc = new DOMDocument();
+		$doc->loadHTML( '<body><a href="./F(o)o%E2%99%A5/Bar" title="F(o)o♥/Bar">Bar</a></body>' );
+		$pageParser = new PageParser( $doc );
+		$this->assertCount( 1, $pageParser->getFullChaptersList( 'F(o)o♥', [], [] ) );
+	}
 }


### PR DESCRIPTION
If a work doesn't use ws-summary, we look for all anchors containing
the work's title. This search wasn't being done with a URL-encoded
string.

Also fix an overloaded variable ($title → $linkTitle).

Bug: T270367