### PR TITLE
Transliterate element IDs and fix replacement process

### DIFF
--- a/tests/Book/PageParserTest.php
+++ b/tests/Book/PageParserTest.php
@@ -90,10 +90,11 @@ class PageParserTest extends TestCase {
 		$pageParser2->getContent( false );
 
 		// Test outputs.
+		$this->assertCount( 9, PageParser::getIds() );
 		$this->assertArrayHasKey( 'id-1', PageParser::getIds() );
-		$this->assertArrayHasKey( 'id-1-n2', PageParser::getIds() );
+		$this->assertArrayHasKey( 'id-1-n8', PageParser::getIds() );
 		$this->assertArrayHasKey( 'lorem', PageParser::getIds() );
-		$this->assertArrayHasKey( 'lorem-n2', PageParser::getIds() );
+		$this->assertArrayHasKey( 'lorem-n9', PageParser::getIds() );
 		$this->assertArrayHasKey( 'id-.123_foo:bar', PageParser::getIds() );
 
 		$this->assertStringContainsString( '<span id="id-1"></span>', $html );


### PR DESCRIPTION
The existing system was still creating duplicates where there were
no ascii characters in the original ID (they were all replaced by
underscores, so only had to match on the length).

Also switched from appending a count of each duplicate ID to just
using a count of all IDs in order to create a unique ID, because
array_count_values() isn't very fast and we don't actually care
about this number.

Bug: T272119