### PR TITLE
Remove attribute escaping from title

### DIFF
--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -19,7 +19,7 @@
 
 			<div class="col-lg-10">
 				<input name="page" id="page" type="text" size="30" required="required" class="form-control"
-					value="{{ title|e('html_attr') }}" />
+					value="{{ title }}" />
 				<span class="help-block">Name of the mainpage of the book in Wikisource</span>
 			</div>
 		</div>

--- a/tests/Http/BookTest.php
+++ b/tests/Http/BookTest.php
@@ -90,8 +90,8 @@ class BookTest extends WebTestCase {
 
 	public function testTitlePrefill() {
 		$client = static::createClient();
-		$client->request( 'GET', '/', [ 'title' => 'A title' ] );
+		$client->request( 'GET', '/', [ 'title' => 'A "title"' ] );
 		$this->assertStringContainsString( '<input name="page" id="page" type="text" size="30" required="required" class="form-control"
-					value="A&#x20;title" />', $client->getResponse()->getContent() );
+					value="A &quot;title&quot;" />', $client->getResponse()->getContent() );
 	}
 }


### PR DESCRIPTION
Just use normal HTML variable escaping (which does take care of
quotation marks, and doesn't fail with an error for invalid
strings as shown in the bug).

Bug: T272181