### PR TITLE
Don't remove child nodes of figures and images.

### DIFF
--- a/tests/Book/PageParserTest.php
+++ b/tests/Book/PageParserTest.php
@@ -147,4 +147,46 @@ class PageParserTest extends TestCase {
 		$pageParser = new PageParser( $doc );
 		$this->assertCount( 1, $pageParser->getFullChaptersList( 'F(o)o♥', [], [] ) );
 	}
+
+	/**
+	 * @dataProvider provideGetPicturesList
+	 */
+	public function testGetPicturesList( string $in, string $out, string $picTitle, string $picName ): void {
+		$doc1 = new DOMDocument();
+		$doc1->loadXML( $in );
+		$pageParser1 = new PageParser( $doc1 );
+		$pictures = $pageParser1->getPicturesList();
+		$this->assertStringContainsString( $out, $pageParser1->getContent( false )->saveXML() );
+		$this->assertSame( $picTitle, $pictures[$picTitle]->title );
+		$this->assertSame( $picName, $pictures[$picTitle]->name );
+	}
+
+	public function provideGetPicturesList(): array {
+		return [
+			'Image gets a data-title attribute'  => [
+				'<p><img src="foo/bar.jpg" /></p>',
+				'<p><img src="foo/bar.jpg" data-title="bar.jpg"/></p>',
+				'bar.jpg',
+				'bar.jpg',
+			],
+			'Figure caption is not removed' => [
+				'<figure><img src="foo/bar.jpg" /><figcaption>Lorem</figcaption></figure>',
+				'<figure><img src="foo/bar.jpg" data-title="bar.jpg"/><figcaption>Lorem</figcaption></figure>',
+				'bar.jpg',
+				'bar.jpg',
+			],
+			'Title extracted from MediaWiki non-thumb URL' => [
+				'<p><img src="//example.org/0/00/example.jpg" /></p>',
+				'<p><img src="//example.org/0/00/example.jpg" data-title="example.jpg"/></p>',
+				'example.jpg',
+				'example.jpg',
+			],
+			'Title extracted from MediaWiki thumb URL' => [
+				'<p><a class="image"><img src="//example.org/thumb/2/9A/example.jpg/500px-example.jpg" /></a></p>',
+				'<p><a class="image"><img src="//example.org/thumb/2/9A/example.jpg/500px-example.jpg" data-title="example.jpg-500px-example.jpg"/></a></p>',
+				'example.jpg-500px-example.jpg',
+				'example.jpg',
+			],
+		];
+	}
 }


### PR DESCRIPTION
When processing img elements, this was replacing figure and
figure-inline with an img element. This was discarding any
figcaption or other contents of the node.

It doesn't look like there's any reason to do this replacement,
as we're already modifying the img element to our requirements.

Also switch to ctype_xdigit to check for the thumb URL segments
being valid hex digits, because using is_numeric to do this was
deprecated as of PHP 7.0.

Also check for any contained img elements in figure etc. and break
if none found.

Bug: https://phabricator.wikimedia.org/T272307
Bug: https://phabricator.wikimedia.org/T272180
