### PR TITLE
Hard-code check for Multilingual Wikisource to avoid errors

### DIFF
--- a/tests/WikidataTest.php
+++ b/tests/WikidataTest.php
@@ -25,14 +25,14 @@ class WikidataTest extends TestCase {
 	public function testLanguageList() {
 		// Get the list in English and most are in their own language.
 		$langs = $this->wikidata->getWikisourceLangs( 'en' );
-		$this->assertSame( $langs['sv'], 'svenskspråkiga Wikisource' );
-		$this->assertSame( $langs['en'], 'English Wikisource' );
-		$this->assertSame( $langs['mul'], 'Multilingual Wikisource' );
+		$this->assertSame( 'svenskspråkiga Wikisource', $langs['sv'] );
+		$this->assertSame( 'English Wikisource', $langs['en'] );
+		$this->assertSame( 'Multilingual Wikisource', $langs['mul'] );
 		// Get the list in a different language and the only one changed should be mul.
 		$langs2 = $this->wikidata->getWikisourceLangs( 'fr' );
-		$this->assertSame( $langs2['en'], 'English Wikisource' );
-		$this->assertSame( $langs2['sv'], 'svenskspråkiga Wikisource' );
-		$this->assertSame( $langs2['mul'], 'Wikisource multilingue' );
+		$this->assertSame( 'English Wikisource', $langs2['en'] );
+		$this->assertSame( 'svenskspråkiga Wikisource', $langs2['sv'] );
+		$this->assertSame( 'Wikisource multilingue', $langs2['mul'] );
 		// Note that this test doesn't test the fallback to the interface language for missing local labels,
 		// because this will hopefully be fixed on Wikidata and so wouldn't be repeatable.
 	}


### PR DESCRIPTION
Rather than looking for an empty subdomain, check for the Wikidata ID of Multilingual Wikisource.

Bug: T342520